### PR TITLE
Dealing with failed-create-object

### DIFF
--- a/account/api.go
+++ b/account/api.go
@@ -54,16 +54,16 @@ func (api *PrivateAPI) GetUserOplogMerkleNodeList(profileID string, level uint8,
  * UserNode
  **********/
 
-func (api *PrivateAPI) GetUserNodeList(idStr string, startID string, limit int, listOrder pttdb.ListOrder) ([]*UserNode, error) {
-	return api.b.GetUserNodeList([]byte(idStr), []byte(startID), limit, listOrder)
+func (api *PrivateAPI) GetUserNodeList(entityID string, startID string, limit int, listOrder pttdb.ListOrder) ([]*UserNode, error) {
+	return api.b.GetUserNodeList([]byte(entityID), []byte(startID), limit, listOrder)
 }
 
-func (api *PrivateAPI) GetUserNodeInfo(idStr string) (*UserNodeInfo, error) {
-	return api.b.GetUserNodeInfo([]byte(idStr))
+func (api *PrivateAPI) GetUserNodeInfo(entityID string) (*UserNodeInfo, error) {
+	return api.b.GetUserNodeInfo([]byte(entityID))
 }
 
-func (api *PrivateAPI) RemoveUserNode(entityIDStr string, nodeIDStr string) (types.Bool, error) {
-	return api.b.RemoveUserNode([]byte(entityIDStr), []byte(nodeIDStr))
+func (api *PrivateAPI) RemoveUserNode(entityID string, nodeIDStr string) (types.Bool, error) {
+	return api.b.RemoveUserNode([]byte(entityID), []byte(nodeIDStr))
 }
 
 /**********

--- a/account/protocol_add_user_node.go
+++ b/account/protocol_add_user_node.go
@@ -38,8 +38,19 @@ func (pm *ProtocolManager) AddUserNode(nodeID *discover.NodeID) error {
 
 	log.Debug("AddUserNode: to CreateObject", "entity", pm.Entity().GetID())
 	_, err := pm.CreateObject(
-		data, UserOpTypeAddUserNode,
-		pm.NewUserNode, pm.NewUserOplogWithTS, nil, pm.broadcastUserOplogCore, pm.postcreateUserNode)
+		data,
+		UserOpTypeAddUserNode,
+
+		pm.NewUserNode,
+		pm.NewUserOplogWithTS,
+		nil,
+
+		pm.SetUserDB,
+		pm.broadcastUserOplogsCore,
+		pm.broadcastUserOplogCore,
+
+		pm.postcreateUserNode,
+	)
 	log.Debug("AddUserNode: after CreateObject", "entity", pm.Entity().GetID(), "nodeID", nodeID, "e", err)
 	if err != nil {
 		return err

--- a/account/protocol_create_user_img.go
+++ b/account/protocol_create_user_img.go
@@ -29,7 +29,20 @@ func (pm *ProtocolManager) CreateUserImg() error {
 		return types.ErrInvalidID
 	}
 
-	_, err := pm.CreateObject(nil, UserOpTypeCreateUserImg, pm.NewUserImg, pm.NewUserOplogWithTS, nil, pm.broadcastUserOplogCore, nil)
+	_, err := pm.CreateObject(
+		nil,
+		UserOpTypeCreateUserImg,
+
+		pm.NewUserImg,
+		pm.NewUserOplogWithTS,
+		nil,
+
+		pm.SetUserDB,
+		pm.broadcastUserOplogsCore,
+		pm.broadcastUserOplogCore,
+
+		nil,
+	)
 	if err != nil {
 		return err
 	}

--- a/account/protocol_create_user_name.go
+++ b/account/protocol_create_user_name.go
@@ -29,7 +29,20 @@ func (pm *ProtocolManager) CreateUserName(name []byte) error {
 		return types.ErrInvalidID
 	}
 
-	_, err := pm.CreateObject(nil, UserOpTypeCreateUserName, pm.NewUserName, pm.NewUserOplogWithTS, nil, pm.broadcastUserOplogCore, nil)
+	_, err := pm.CreateObject(
+		nil,
+		UserOpTypeCreateUserName,
+
+		pm.NewUserName,
+		pm.NewUserOplogWithTS,
+		nil,
+
+		pm.SetUserDB,
+		pm.broadcastUserOplogsCore,
+		pm.broadcastUserOplogCore,
+
+		nil,
+	)
 	if err != nil {
 		return err
 	}

--- a/account/protocol_manager.go
+++ b/account/protocol_manager.go
@@ -165,6 +165,9 @@ func (pm *ProtocolManager) Stop() error {
 func (pm *ProtocolManager) Sync(peer *pkgservice.PttPeer) error {
 	log.Debug("Sync: start", "entity", pm.Entity().GetID(), "peer", peer, "service", pm.Entity().Service().Name(), "status", pm.Entity().GetStatus())
 	if peer == nil {
+		pm.SyncPendingMasterOplog(peer)
+		pm.SyncPendingMemberOplog(peer)
+		pm.SyncPendingUserOplog(peer)
 		return nil
 	}
 

--- a/account/protocol_user_oplog.go
+++ b/account/protocol_user_oplog.go
@@ -38,19 +38,6 @@ func (pm *ProtocolManager) CreateUserOplog(objID *types.PttID, ts types.Timestam
 	return oplog, nil
 }
 
-func (pm *ProtocolManager) GetPendingUserOplogs() ([]*UserOplog, []*UserOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetUserDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	typedLogs := OplogsToUserOplogs(oplogs)
-
-	failedUserLogs := OplogsToUserOplogs(failedLogs)
-
-	return typedLogs, failedUserLogs, nil
-}
-
 /**********
  * BroadcastUserOplog
  **********/

--- a/cmd/gptt/globals.go
+++ b/cmd/gptt/globals.go
@@ -68,6 +68,17 @@ var (
 		utils.ContentKeystoreDirFlag,
 	}
 
+	// flags that configure content
+	friendFlags = []cli.Flag{
+		utils.FriendMaxSyncRandomSecondsFlag,
+		utils.FriendMinSyncRandomSecondsFlag,
+	}
+
+	// flags that configure content
+	serviceFlags = []cli.Flag{
+		utils.ServiceExpireOplogSecondsFlag,
+	}
+
 	// flags that configure http-server
 	httpFlags = []cli.Flag{
 		utils.HTTPAddrFlag,

--- a/cmd/gptt/main.go
+++ b/cmd/gptt/main.go
@@ -78,6 +78,8 @@ func InitApp() *cli.App {
 	app.Flags = append(app.Flags, nodeFlags...)
 	app.Flags = append(app.Flags, meFlags...)
 	app.Flags = append(app.Flags, contentFlags...)
+	app.Flags = append(app.Flags, friendFlags...)
+	app.Flags = append(app.Flags, serviceFlags...)
 	app.Flags = append(app.Flags, rpcFlags...)
 	app.Flags = append(app.Flags, httpFlags...)
 	app.Flags = append(app.Flags, networkFlags...)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -106,6 +106,12 @@ var (
 		Usage: "set as server mode",
 	}
 
+	// service settings
+	ServiceExpireOplogSecondsFlag = cli.IntFlag{
+		Name:  "serviceexpireoplog",
+		Usage: "expire oplog seconds",
+	}
+
 	// Content settings
 	ContentDataDirFlag = DirectoryFlag{
 		Name:  "contentdatadir",
@@ -117,6 +123,17 @@ var (
 		Name:  "contentkeystoredir",
 		Usage: "Keystore directory for content",
 		Value: DirectoryString{content.DefaultConfig.KeystoreDir},
+	}
+
+	// Friend settings
+	FriendMaxSyncRandomSecondsFlag = cli.IntFlag{
+		Name:  "friendmaxsync",
+		Usage: "max sync random seconds",
+	}
+
+	FriendMinSyncRandomSecondsFlag = cli.IntFlag{
+		Name:  "friendminsync",
+		Usage: "min sync random seconds",
 	}
 
 	// Performance tuning settings

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -138,6 +138,17 @@ func SetFriendConfig(ctx *cli.Context, cfg *friend.Config, cfgNode *node.Config)
 	// datadir
 	log.Debug("SetFriendConfig: to set DataDir", "cfgNode.DataDIR", cfgNode.DataDir)
 	cfg.DataDir = filepath.Join(cfgNode.DataDir, "friend")
+
+	if ctx.GlobalIsSet(FriendMaxSyncRandomSecondsFlag.Name) {
+		cfg.MaxSyncRandomSeconds = ctx.GlobalInt(FriendMaxSyncRandomSecondsFlag.Name)
+	}
+
+	if ctx.GlobalIsSet(FriendMinSyncRandomSecondsFlag.Name) {
+		cfg.MinSyncRandomSeconds = ctx.GlobalInt(FriendMinSyncRandomSecondsFlag.Name)
+	}
+
+	friend.MaxSyncRandomSeconds = cfg.MaxSyncRandomSeconds
+	friend.MinSyncRandomSeconds = cfg.MinSyncRandomSeconds
 }
 
 // SetPttConfig applies ptt-related command line flags to the config.
@@ -157,6 +168,16 @@ func SetPttConfig(ctx *cli.Context, cfg *pkgservice.Config, cfgNode *node.Config
 	default:
 		cfg.NodeType = pkgservice.NodeTypeDesktop
 	}
+
+	// expire oplog seconds
+	if ctx.GlobalIsSet(ServiceExpireOplogSecondsFlag.Name) {
+		cfg.ExpireOplogSeconds = ctx.GlobalInt(ServiceExpireOplogSecondsFlag.Name)
+	}
+
+	pkgservice.ExpireOplogSeconds = cfg.ExpireOplogSeconds
+
+	log.Debug("SetPttConfig: to return", "ExpireOplogSeconds", pkgservice.ExpireOplogSeconds)
+
 }
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/content/protocol_board_oplog.go
+++ b/content/protocol_board_oplog.go
@@ -38,19 +38,6 @@ func (pm *ProtocolManager) CreateBoardOplog(objID *types.PttID, ts types.Timesta
 	return oplog, nil
 }
 
-func (pm *ProtocolManager) GetPendingBoardOplogs() ([]*BoardOplog, []*BoardOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetBoardDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	typedLogs := OplogsToBoardOplogs(oplogs)
-
-	failedBoardLogs := OplogsToBoardOplogs(failedLogs)
-
-	return typedLogs, failedBoardLogs, nil
-}
-
 /**********
  * BroadcastBoardOplog
  **********/

--- a/content/protocol_create_article.go
+++ b/content/protocol_create_article.go
@@ -45,7 +45,20 @@ func (pm *ProtocolManager) CreateArticle(title []byte, articleBytes [][]byte, me
 		MediaIDs: mediaIDs,
 	}
 
-	theArticle, err := pm.CreateObject(data, BoardOpTypeCreateArticle, pm.NewArticle, pm.NewBoardOplogWithTS, pm.increateArticle, pm.broadcastBoardOplogCore, pm.postcreateArticle)
+	theArticle, err := pm.CreateObject(
+		data,
+		BoardOpTypeCreateArticle,
+
+		pm.NewArticle,
+		pm.NewBoardOplogWithTS,
+		pm.increateArticle,
+
+		pm.SetBoardDB,
+		pm.broadcastBoardOplogsCore,
+		pm.broadcastBoardOplogCore,
+
+		pm.postcreateArticle,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/content/protocol_create_comment.go
+++ b/content/protocol_create_comment.go
@@ -44,7 +44,20 @@ func (pm *ProtocolManager) CreateComment(articleID *types.PttID, commentType Com
 		MediaIDs:    mediaIDs,
 	}
 
-	theComment, err := pm.CreateObject(data, BoardOpTypeCreateComment, pm.NewComment, pm.NewBoardOplogWithTS, pm.increateComment, pm.broadcastBoardOplogCore, pm.postcreateComment)
+	theComment, err := pm.CreateObject(
+		data,
+		BoardOpTypeCreateComment,
+
+		pm.NewComment,
+		pm.NewBoardOplogWithTS,
+		pm.increateComment,
+
+		pm.SetBoardDB,
+		pm.broadcastBoardOplogsCore,
+		pm.broadcastBoardOplogCore,
+
+		pm.postcreateComment,
+	)
 
 	if err != nil {
 		return nil, err

--- a/content/protocol_create_title.go
+++ b/content/protocol_create_title.go
@@ -34,7 +34,19 @@ func (pm *ProtocolManager) CreateTitle(title []byte) error {
 
 	data := &CreateTitle{Title: title}
 
-	_, err := pm.CreateObject(data, BoardOpTypeCreateTitle, pm.NewTitle, pm.NewBoardOplogWithTS, nil, pm.broadcastBoardOplogCore, nil)
+	_, err := pm.CreateObject(
+		data,
+		BoardOpTypeCreateTitle,
+
+		pm.NewTitle,
+		pm.NewBoardOplogWithTS,
+		nil,
+
+		pm.SetBoardDB,
+		pm.broadcastBoardOplogsCore,
+		pm.broadcastBoardOplogCore,
+		nil,
+	)
 	if err != nil {
 		return err
 	}

--- a/content/protocol_manager.go
+++ b/content/protocol_manager.go
@@ -155,6 +155,9 @@ func (pm *ProtocolManager) Stop() error {
 func (pm *ProtocolManager) Sync(peer *pkgservice.PttPeer) error {
 	log.Debug("Sync: start", "entity", pm.Entity().GetID(), "peer", peer, "service", pm.Entity().Service().Name(), "status", pm.Entity().GetStatus())
 	if peer == nil {
+		pm.SyncPendingMasterOplog(peer)
+		pm.SyncPendingMemberOplog(peer)
+		pm.SyncPendingBoardOplog(peer)
 		return nil
 	}
 

--- a/content/protocol_upload_file.go
+++ b/content/protocol_upload_file.go
@@ -39,7 +39,20 @@ func (pm *ProtocolManager) UploadFile(filename []byte, theBytes []byte) (*pkgser
 		Bytes:    theBytes,
 	}
 
-	theMedia, err := pm.CreateObject(data, BoardOpTypeCreateMedia, pm.NewMedia, pm.NewBoardOplogWithTS, pm.increateFile, pm.broadcastBoardOplogCore, nil)
+	theMedia, err := pm.CreateObject(
+		data,
+		BoardOpTypeCreateMedia,
+
+		pm.NewMedia,
+		pm.NewBoardOplogWithTS,
+		pm.increateFile,
+
+		pm.SetBoardDB,
+		pm.broadcastBoardOplogsCore,
+		pm.broadcastBoardOplogCore,
+
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/content/protocol_upload_image.go
+++ b/content/protocol_upload_image.go
@@ -38,7 +38,20 @@ func (pm *ProtocolManager) UploadImage(fileType string, theBytes []byte) (*pkgse
 		Bytes:    theBytes,
 	}
 
-	theMedia, err := pm.CreateObject(data, BoardOpTypeCreateMedia, pm.NewMedia, pm.NewBoardOplogWithTS, pm.inuploadImage, pm.broadcastBoardOplogCore, nil)
+	theMedia, err := pm.CreateObject(
+		data,
+		BoardOpTypeCreateMedia,
+
+		pm.NewMedia,
+		pm.NewBoardOplogWithTS,
+		pm.inuploadImage,
+
+		pm.SetBoardDB,
+		pm.broadcastBoardOplogsCore,
+		pm.broadcastBoardOplogCore,
+
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/friend_msg_restart_test.go
+++ b/e2e/friend_msg_restart_test.go
@@ -31,7 +31,7 @@ import (
 	baloo "gopkg.in/h2non/baloo.v3"
 )
 
-func TestFriendMsg(t *testing.T) {
+func TestFriendMsgRestart(t *testing.T) {
 	NNodes = 2
 	isDebug := true
 
@@ -253,7 +253,7 @@ func TestFriendMsg(t *testing.T) {
 	assert.Equal(2, len(dataMemberList1_12_1.Result))
 	assert.Equal(dataMemberList0_12_1, dataMemberList1_12_1)
 
-	// 13. create-msg
+	// 35. friend-create-message
 	msg, _ := json.Marshal([]string{
 		base64.StdEncoding.EncodeToString([]byte("測試1")),
 		base64.StdEncoding.EncodeToString([]byte("測試2")),
@@ -279,7 +279,6 @@ func TestFriendMsg(t *testing.T) {
 		base64.StdEncoding.EncodeToString([]byte("測試22")),
 	})
 
-	// 35. friend-create-message
 	marshaled, _ = friend0_8.ID.MarshalText()
 
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "friend_createMessage", "params": ["%v", %v, []]}`, string(marshaled), string(msg))
@@ -385,4 +384,102 @@ func TestFriendMsg(t *testing.T) {
 
 	assert.Equal(article0, dataGetMessageBlockList1_37.Result[0].Buf)
 	assert.Equal(article1, dataGetMessageBlockList1_37.Result[1].Buf)
+
+	// 39. ptt-shutdown
+	bodyString = `{"id": "testID", "method": "ptt_shutdown", "params": []}`
+
+	resultString := `{"jsonrpc":"2.0","id":"testID","result":true}`
+	testBodyEqualCore(t0, bodyString, resultString, t)
+
+	time.Sleep(5 * time.Second)
+
+	// 40. test-error
+	err0_40 := testError("http://127.0.0.1:9450")
+	assert.NotEqual(nil, err0_40)
+
+	// 40.1. ptt_countPeers. ensure connecting to each other.
+	bodyString = `{"id": "testID", "method": "ptt_countPeers", "params": []}`
+	resultString = `{"jsonrpc":"2.0","id":"testID","result":{"M":0,"I":0,"E":0,"R":0}}`
+	testBodyEqualCore(t1, bodyString, resultString, t)
+
+	// 41. friend-create-message
+	t.Logf("41. friend-create-message")
+	msg41, _ := json.Marshal([]string{
+		base64.StdEncoding.EncodeToString([]byte("測試31")),
+		base64.StdEncoding.EncodeToString([]byte("測試32")),
+		base64.StdEncoding.EncodeToString([]byte("測試33")),
+		base64.StdEncoding.EncodeToString([]byte("測試34")),
+		base64.StdEncoding.EncodeToString([]byte("測試35")),
+		base64.StdEncoding.EncodeToString([]byte("測試36")),
+		base64.StdEncoding.EncodeToString([]byte("測試37")),
+		base64.StdEncoding.EncodeToString([]byte("測試38")),
+		base64.StdEncoding.EncodeToString([]byte("測試39")),
+		base64.StdEncoding.EncodeToString([]byte("測試40")),
+	})
+
+	marshaled, _ = friend0_8.ID.MarshalText()
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "friend_createMessage", "params": ["%v", %v, []]}`, string(marshaled), string(msg41))
+	dataCreateMessage1_41 := &friend.BackendCreateMessage{}
+	testCore(t1, bodyString, dataCreateMessage1_41, t, isDebug)
+	assert.Equal(friend0_8.ID, dataCreateMessage1_41.FriendID)
+	assert.Equal(1, dataCreateMessage1_41.NBlock)
+
+	time.Sleep(15 * time.Second)
+
+	// 42. friend-get-message-list
+	t.Logf("42. friend-get-message-list")
+	marshaled, _ = friend0_8.ID.MarshalText()
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "friend_getMessageList", "params": ["%v", "", 0, 2]}`, string(marshaled))
+	dataGetMessageList1_42 := &struct {
+		Result []*friend.BackendGetMessage `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMessageList1_42, t, isDebug)
+	assert.Equal(2, len(dataGetMessageList1_42.Result))
+
+	msg1_42 := dataGetMessageList1_42.Result[1]
+	assert.Equal(1, msg1_42.NBlock)
+	assert.Equal(types.StatusPending, msg1_42.Status)
+
+	// 43. start-node
+	startNode(t, 0)
+
+	// wait 15 seconds
+
+	time.Sleep(15 * time.Second)
+
+	// 43.1. test-error
+	err0_43_1 := testError("http://127.0.0.1:9450")
+	assert.Equal(nil, err0_43_1)
+
+	// 44_2. ptt_countPeers. ensure connecting to each other.
+	bodyString = `{"id": "testID", "method": "ptt_countPeers", "params": []}`
+	resultString = `{"jsonrpc":"2.0","id":"testID","result":{"M":0,"I":1,"E":0,"R":0}}`
+	testBodyEqualCore(t0, bodyString, resultString, t)
+	testBodyEqualCore(t1, bodyString, resultString, t)
+
+	// 45. friend-get-message-list
+	marshaled, _ = friend0_8.ID.MarshalText()
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "friend_getMessageList", "params": ["%v", "", 0, 2]}`, string(marshaled))
+	dataGetMessageList0_45 := &struct {
+		Result []*friend.BackendGetMessage `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetMessageList0_45, t, isDebug)
+	assert.Equal(2, len(dataGetMessageList0_45.Result))
+
+	msg0_45 := dataGetMessageList0_45.Result[1]
+	assert.Equal(types.StatusAlive, msg0_45.Status)
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "friend_getMessageList", "params": ["%v", "", 0, 2]}`, string(marshaled))
+	dataGetMessageList1_45 := &struct {
+		Result []*friend.BackendGetMessage `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMessageList1_45, t, isDebug)
+	assert.Equal(2, len(dataGetMessageList1_45.Result))
+
+	msg1_45 := dataGetMessageList1_45.Result[1]
+	assert.Equal(types.StatusAlive, msg1_45.Status)
+
 }

--- a/e2e/multi_device3_delete_comment_test.go
+++ b/e2e/multi_device3_delete_comment_test.go
@@ -697,6 +697,9 @@ func TestMultiDevice3DeleteComment(t *testing.T) {
 	assert.Equal(dataCreateArticle0_35.ArticleID, dataCreateComment0_43.ArticleID)
 	assert.Equal(dataCreateArticle0_35.BoardID, dataCreateComment0_43.BoardID)
 
+	// wait 3 seconds
+	time.Sleep(3 * time.Second)
+
 	// 44. content-create-comment
 	commentBytes0_44 := []byte("這是comment44")
 	commentStr = base64.StdEncoding.EncodeToString(commentBytes0_44)
@@ -710,6 +713,9 @@ func TestMultiDevice3DeleteComment(t *testing.T) {
 	testCore(t0, bodyString, dataCreateComment0_44, t, isDebug)
 	assert.Equal(dataCreateArticle0_35.ArticleID, dataCreateComment0_44.ArticleID)
 	assert.Equal(dataCreateArticle0_35.BoardID, dataCreateComment0_44.BoardID)
+
+	// wait 3 seconds
+	time.Sleep(3 * time.Second)
 
 	// 45. content-create-comment
 	commentBytes0_45 := []byte("這是comment45")
@@ -725,8 +731,8 @@ func TestMultiDevice3DeleteComment(t *testing.T) {
 	assert.Equal(dataCreateArticle0_35.ArticleID, dataCreateComment0_45.ArticleID)
 	assert.Equal(dataCreateArticle0_35.BoardID, dataCreateComment0_45.BoardID)
 
-	// wait 10 seconds
-	time.Sleep(10 * time.Second)
+	// wait 3 seconds
+	time.Sleep(3 * time.Second)
 
 	// 46. get-article-block
 	marshaledID2, _ = article0_36.ID.MarshalText()

--- a/e2e/multi_device_sync_board_test.go
+++ b/e2e/multi_device_sync_board_test.go
@@ -142,7 +142,7 @@ func TestMultiDeviceSyncBoard(t *testing.T) {
 
 	// wait 10
 	t.Logf("wait 10 seconds for hand-shaking")
-	time.Sleep(10 * time.Second)
+	time.Sleep(TimeSleepRestart)
 
 	// 8. me_GetMyNodes
 	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`

--- a/e2e/multi_device_sync_friend_test.go
+++ b/e2e/multi_device_sync_friend_test.go
@@ -152,8 +152,8 @@ func TestMultiDeviceSyncFriend(t *testing.T) {
 	assert.Equal(me1_1.NodeID, dataJoinMe0_7.NodeID)
 
 	// wait 10
-	t.Logf("wait 12 seconds for hand-shaking")
-	time.Sleep(12 * time.Second)
+	t.Logf("wait 15 seconds for hand-shaking")
+	time.Sleep(TimeSleepRestart)
 
 	// 8. me_GetMyNodes
 	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`

--- a/friend/backend_core.go
+++ b/friend/backend_core.go
@@ -19,6 +19,7 @@ package friend
 import (
 	"github.com/ailabstw/go-pttai/account"
 	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
 	"github.com/ailabstw/go-pttai/pttdb"
 	pkgservice "github.com/ailabstw/go-pttai/service"
 )
@@ -191,6 +192,7 @@ func (b *Backend) CreateMessage(entityIDBytes []byte, message [][]byte, mediaIDS
 	}
 
 	theMessage, err := pm.CreateMessage(message, mediaIDs)
+	log.Debug("CreateMessage: after CreateMessage", "e", err)
 	if err != nil {
 		return nil, err
 	}

--- a/friend/config.go
+++ b/friend/config.go
@@ -18,6 +18,9 @@ package friend
 
 type Config struct {
 	DataDir string
+
+	MaxSyncRandomSeconds int
+	MinSyncRandomSeconds int
 }
 
 func NewConfig() (*Config, error) {

--- a/friend/friend.go
+++ b/friend/friend.go
@@ -118,6 +118,26 @@ func (f *Friend) Init(ptt pkgservice.Ptt, service pkgservice.Service, spm pkgser
 		return err
 	}
 
+	// profile
+	accountSPM := service.(*Backend).accountBackend.SPM()
+	if f.ProfileID != nil {
+		profile := accountSPM.Entity(f.ProfileID)
+		if profile == nil {
+			return pkgservice.ErrInvalidEntity
+		}
+		f.Profile = profile.(*account.Profile)
+	}
+
+	// board
+	contentSPM := service.(*Backend).contentBackend.SPM()
+	if f.BoardID != nil {
+		board := contentSPM.Entity(f.BoardID)
+		if board == nil {
+			return pkgservice.ErrInvalidEntity
+		}
+		f.Board = board.(*content.Board)
+	}
+
 	return nil
 }
 

--- a/friend/globals.go
+++ b/friend/globals.go
@@ -28,6 +28,9 @@ import (
 var (
 	DefaultConfig = Config{
 		DataDir: filepath.Join(node.DefaultDataDir(), "friend"),
+
+		MaxSyncRandomSeconds: 20,
+		MinSyncRandomSeconds: 10,
 	}
 )
 
@@ -88,7 +91,7 @@ const (
 )
 
 // sync
-const (
+var (
 	MaxSyncRandomSeconds = 20
 	MinSyncRandomSeconds = 10
 )

--- a/friend/protocol_create_message.go
+++ b/friend/protocol_create_message.go
@@ -40,7 +40,20 @@ func (pm *ProtocolManager) CreateMessage(msg [][]byte, mediaIDs []*types.PttID) 
 		MediaIDs: mediaIDs,
 	}
 
-	theMessage, err := pm.CreateObject(data, FriendOpTypeCreateMessage, pm.NewMessage, pm.NewFriendOplogWithTS, pm.increateMessage, pm.broadcastFriendOplogCore, pm.postcreateMessage)
+	theMessage, err := pm.CreateObject(
+		data,
+		FriendOpTypeCreateMessage,
+
+		pm.NewMessage,
+		pm.NewFriendOplogWithTS,
+		pm.increateMessage,
+
+		pm.SetFriendDB,
+		pm.broadcastFriendOplogsCore,
+		pm.broadcastFriendOplogCore,
+
+		pm.postcreateMessage,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/friend/protocol_create_message_logs.go
+++ b/friend/protocol_create_message_logs.go
@@ -59,6 +59,8 @@ func (pm *ProtocolManager) handleFailedCreateMessageLog(oplog *pkgservice.BaseOp
 	obj := NewEmptyMessage()
 	pm.SetMessageDB(obj)
 
+	log.Debug("handleFailedCreateMessageLog: to HandleFailedCreateObjectLog")
+
 	return pm.HandleFailedCreateObjectLog(oplog, obj, nil)
 }
 

--- a/friend/protocol_friend_oplog.go
+++ b/friend/protocol_friend_oplog.go
@@ -38,19 +38,6 @@ func (pm *ProtocolManager) CreateFriendOplog(objID *types.PttID, ts types.Timest
 	return oplog, nil
 }
 
-func (pm *ProtocolManager) GetPendingFriendOplogs() ([]*FriendOplog, []*FriendOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetFriendDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	opKeyLogs := OplogsToFriendOplogs(oplogs)
-
-	failedFriendLogs := OplogsToFriendOplogs(failedLogs)
-
-	return opKeyLogs, failedFriendLogs, nil
-}
-
 /**********
  * BroadcastFriendOplog
  **********/

--- a/friend/protocol_get_friend_by_friend_id.go
+++ b/friend/protocol_get_friend_by_friend_id.go
@@ -34,3 +34,19 @@ func (spm *ServiceProtocolManager) GetFriendByFriendID(friendID *types.PttID) (*
 
 	return f, nil
 }
+
+func (spm *ServiceProtocolManager) GetFriendEntityByFriendID(friendID *types.PttID) (*Friend, error) {
+	f := NewEmptyFriend()
+
+	err := f.GetByFriendID(friendID)
+	if err != nil {
+		return nil, err
+	}
+
+	entity := spm.Entity(f.ID)
+	if entity == nil {
+		return nil, types.ErrInvalidID
+	}
+
+	return entity.(*Friend), nil
+}

--- a/friend/protocol_manager.go
+++ b/friend/protocol_manager.go
@@ -77,9 +77,10 @@ func (pm *ProtocolManager) Start() error {
 		return err
 	}
 
+	pm.LoadPeers()
+
 	// oplog-merkle-tree
 	syncWG := pm.SyncWG()
-
 	syncWG.Add(1)
 	go func() {
 		defer syncWG.Done()
@@ -97,6 +98,9 @@ func (pm *ProtocolManager) Stop() error {
 func (pm *ProtocolManager) Sync(peer *pkgservice.PttPeer) error {
 	log.Debug("Sync: start", "entity", pm.Entity().GetID(), "peer", peer, "service", pm.Entity().Service().Name(), "status", pm.Entity().GetStatus())
 	if peer == nil {
+		pm.SyncPendingMasterOplog(peer)
+		pm.SyncPendingMemberOplog(peer)
+		pm.SyncPendingFriendOplog(peer)
 		return nil
 	}
 

--- a/friend/protocol_manager_utils_peer.go
+++ b/friend/protocol_manager_utils_peer.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package friend
+
+import (
+	"math/rand"
+
+	"github.com/ailabstw/go-pttai/account"
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+	"github.com/ailabstw/go-pttai/p2p/discover"
+	"github.com/ailabstw/go-pttai/pttdb"
+	pkgservice "github.com/ailabstw/go-pttai/service"
+)
+
+func (pm *ProtocolManager) LoadPeers() error {
+	userNodeID, err := pm.GetUserNodeID()
+	if err != nil {
+		return err
+	}
+
+	opKey, err := pm.GetOldestOpKey(false)
+	if err != nil {
+		return err
+	}
+
+	ptt := pm.Ptt()
+	ptt.AddDial(userNodeID, opKey.Hash, pkgservice.PeerTypeImportant)
+
+	return nil
+}
+
+func (pm *ProtocolManager) GetUserNodeID() (*discover.NodeID, error) {
+
+	f := pm.Entity().(*Friend)
+
+	if f.Profile == nil {
+		return nil, ErrInvalidFriend
+	}
+
+	profilePM := f.Profile.PM().(*account.ProtocolManager)
+
+	nodeList, err := profilePM.GetUserNodeList(nil, 0, pttdb.ListOrderNext, false)
+	log.Debug("friend.GetUserNodeID: after get UserNodeList", "nodeList", nodeList, "e", err)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodeList) == 0 {
+		return nil, types.ErrInvalidID
+	}
+
+	randInt := rand.Intn(len(nodeList))
+
+	theNode := nodeList[randInt]
+
+	return theNode.NodeID, nil
+}

--- a/me/my_info.go
+++ b/me/my_info.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ailabstw/go-pttai/common"
 	"github.com/ailabstw/go-pttai/common/types"
 	"github.com/ailabstw/go-pttai/content"
+	"github.com/ailabstw/go-pttai/friend"
 	"github.com/ailabstw/go-pttai/log"
 	"github.com/ailabstw/go-pttai/p2p/discover"
 	pkgservice "github.com/ailabstw/go-pttai/service"
@@ -336,5 +337,17 @@ func (m *MyInfo) GetBoard() pkgservice.Entity {
 }
 
 func (m *MyInfo) GetUserNodeID(id *types.PttID) (*discover.NodeID, error) {
-	return nil, types.ErrNotImplemented
+	friendBackend := m.Service().(*Backend).friendBackend
+
+	theFriend, err := friendBackend.SPM().(*friend.ServiceProtocolManager).GetFriendEntityByFriendID(id)
+	if err != nil {
+		return nil, err
+	}
+	if theFriend == nil {
+		return nil, types.ErrInvalidID
+	}
+
+	friendPM := theFriend.PM().(*friend.ProtocolManager)
+
+	return friendPM.GetUserNodeID()
 }

--- a/me/protocol_manager.go
+++ b/me/protocol_manager.go
@@ -296,6 +296,7 @@ func (pm *ProtocolManager) Stop() error {
 
 func (pm *ProtocolManager) Sync(peer *pkgservice.PttPeer) error {
 	if peer == nil {
+		pm.SyncPendingMeOplog(peer)
 		return nil
 	}
 

--- a/me/protocol_me_oplog.go
+++ b/me/protocol_me_oplog.go
@@ -42,19 +42,6 @@ func (pm *ProtocolManager) CreateMeOplog(objID *types.PttID, ts types.Timestamp,
 	return oplog, nil
 }
 
-func (pm *ProtocolManager) GetPendingMeOplogs() ([]*MeOplog, []*MeOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetMeDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	opKeyLogs := OplogsToMeOplogs(oplogs)
-
-	failedMeLogs := OplogsToMeOplogs(failedLogs)
-
-	return opKeyLogs, failedMeLogs, nil
-}
-
 /**********
  * BroadcastMeOplog
  **********/

--- a/pttdb/ldb_database.go
+++ b/pttdb/ldb_database.go
@@ -81,6 +81,7 @@ func NewLDBDatabase(file string, dataDir string, cache int, handles int) (*LDBDa
 		BlockCacheCapacity:     cache / 2 * opt.MiB,
 		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
 		Filter:                 filter.NewBloomFilter(10),
+		CompactionTableSize:    128 * opt.MiB,
 	})
 	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {
 		db, err = leveldb.RecoverFile(fullFilename, nil)

--- a/service/config.go
+++ b/service/config.go
@@ -29,4 +29,6 @@ type Config struct {
 	GitCommit string
 
 	NodeType NodeType
+
+	ExpireOplogSeconds int
 }

--- a/service/globals.go
+++ b/service/globals.go
@@ -35,6 +35,8 @@ var (
 		MaxRandomPeers:    50,
 
 		NodeType: NodeTypeDesktop,
+
+		ExpireOplogSeconds: 30,
 	}
 )
 
@@ -235,7 +237,7 @@ var (
 )
 
 // oplog
-const (
+var (
 	ExpireOplogSeconds = 300 // expire oplog circulation as 5 minutes for now.
 )
 

--- a/service/oplog.go
+++ b/service/oplog.go
@@ -627,8 +627,9 @@ func (o *BaseOplog) MasterSign(id *types.PttID, keyInfo *KeyInfo) error {
 
 	// check expire
 	expireTS := ts
-	expireTS.Ts -= ExpireOplogSeconds
+	expireTS.Ts -= int64(ExpireOplogSeconds)
 	if o.CreateTS.IsLess(expireTS) {
+		log.Error("MasterSign: createTS is less than expireTS", "CreateTS", o.CreateTS, "expireTS", expireTS)
 		return ErrInvalidOplog
 	}
 
@@ -703,7 +704,7 @@ func (o *BaseOplog) InternalSign(id *types.PttID, keyInfo *KeyInfo) error {
 
 	// check expire
 	expireTS := ts
-	expireTS.Ts -= ExpireOplogSeconds
+	expireTS.Ts -= int64(ExpireOplogSeconds)
 	if o.CreateTS.IsLess(expireTS) {
 		log.Error("InternalSign: createTS is less than expireTS", "CreateTS", o.CreateTS, "expireTS", expireTS)
 		return ErrInvalidOplog

--- a/service/protocol_create_op_key.go
+++ b/service/protocol_create_op_key.go
@@ -109,8 +109,18 @@ func (pm *BaseProtocolManager) CreateOpKey() error {
 
 	// 2. create object
 	_, err := pm.CreateObject(
-		nil, OpKeyOpTypeCreateOpKey,
-		pm.NewOpKey, pm.NewOpKeyOplogWithTS, nil, pm.broadcastOpKeyOplogCore, pm.postcreateOpKey)
+		nil,
+		OpKeyOpTypeCreateOpKey,
+		pm.NewOpKey,
+		pm.NewOpKeyOplogWithTS,
+		nil,
+
+		pm.SetOpKeyDB,
+		pm.broadcastOpKeyOplogsCore,
+		pm.broadcastOpKeyOplogCore,
+
+		pm.postcreateOpKey,
+	)
 	if err != nil {
 		log.Warn("CreateOpKeyInfo: unable to CreateObj", "e", err)
 		return err
@@ -130,8 +140,18 @@ func (pm *BaseProtocolManager) ForceCreateOpKey() error {
 
 	// 2. create object
 	_, err := pm.ForceCreateObject(
-		nil, OpKeyOpTypeCreateOpKey,
-		pm.NewOpKey, pm.NewOpKeyOplogWithTS, nil, pm.broadcastOpKeyOplogCore, pm.postcreateOpKey)
+		nil,
+		OpKeyOpTypeCreateOpKey,
+		pm.NewOpKey,
+		pm.NewOpKeyOplogWithTS,
+		nil,
+
+		pm.SetOpKeyDB,
+		pm.broadcastOpKeyOplogsCore,
+		pm.broadcastOpKeyOplogCore,
+
+		pm.postcreateOpKey,
+	)
 	if err != nil {
 		log.Warn("CreateOpKeyInfo: unable to CreateObj", "e", err)
 		return err

--- a/service/protocol_failed_create_object_log.go
+++ b/service/protocol_failed_create_object_log.go
@@ -67,13 +67,20 @@ func (pm *BaseProtocolManager) HandleFailedCreateObjectLog(
 		}
 	}
 
-	blockInfo := obj.GetBlockInfo()
-	err = pm.removeBlockAndMediaInfoByBlockInfo(blockInfo, nil, oplog, true, nil)
-	if err != nil {
-		return err
+	// 5. not my object.
+	myID := pm.Ptt().GetMyEntity().GetID()
+	if !reflect.DeepEqual(myID, obj.GetCreatorID()) {
+		blockInfo := obj.GetBlockInfo()
+		err = pm.removeBlockAndMediaInfoByBlockInfo(blockInfo, nil, oplog, true, nil)
+		if err != nil {
+			return err
+		}
+		obj.Delete(true)
+
+		return nil
 	}
 
-	// 5. obj-save
+	// 6. obj-save
 	ts, err := types.GetTimestamp()
 	if err != nil {
 		return err

--- a/service/protocol_manager_utils_sync.go
+++ b/service/protocol_manager_utils_sync.go
@@ -57,9 +57,6 @@ looping:
 			if err != nil {
 				break looping
 			}
-			if peer == nil {
-				continue
-			}
 
 			pm.SyncOpKeyOplog(peer, SyncOpKeyOplogMsg)
 			err = pm.Sync(peer)

--- a/service/protocol_master_oplog.go
+++ b/service/protocol_master_oplog.go
@@ -16,19 +16,6 @@
 
 package service
 
-func (pm *BaseProtocolManager) GetPendingMasterOplogs() ([]*MasterOplog, []*MasterOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetMasterDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	opKeyLogs := OplogsToMasterOplogs(oplogs)
-
-	failedMasterLogs := OplogsToMasterOplogs(failedLogs)
-
-	return opKeyLogs, failedMasterLogs, nil
-}
-
 /**********
  * BroadcastMasterOplog
  **********/

--- a/service/protocol_member_oplog.go
+++ b/service/protocol_member_oplog.go
@@ -16,19 +16,6 @@
 
 package service
 
-func (pm *BaseProtocolManager) GetPendingMemberOplogs() ([]*MemberOplog, []*MemberOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetMemberDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	opKeyLogs := OplogsToMemberOplogs(oplogs)
-
-	failedMemberLogs := OplogsToMemberOplogs(failedLogs)
-
-	return opKeyLogs, failedMemberLogs, nil
-}
-
 /**********
  * BroadcastMemberOplog
  **********/

--- a/service/protocol_op_key_oplog.go
+++ b/service/protocol_op_key_oplog.go
@@ -16,19 +16,6 @@
 
 package service
 
-func (pm *BaseProtocolManager) GetPendingOpKeyOplogs() ([]*OpKeyOplog, []*OpKeyOplog, error) {
-	oplogs, failedLogs, err := pm.GetPendingOplogs(pm.SetOpKeyDB)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	opKeyLogs := OplogsToOpKeyOplogs(oplogs)
-
-	failedOpKeyLogs := OplogsToOpKeyOplogs(failedLogs)
-
-	return opKeyLogs, failedOpKeyLogs, nil
-}
-
 /**********
  * BroadcastOpKeyOplog
  **********/

--- a/service/protocol_sync_op_key_oplog.go
+++ b/service/protocol_sync_op_key_oplog.go
@@ -38,6 +38,10 @@ func (pm *BaseProtocolManager) SyncOpKeyOplog(peer *PttPeer, syncMsg OpType) err
 		return err
 	}
 
+	if peer == nil {
+		return nil
+	}
+
 	data := &SyncOpKeyOplog{
 		Oplogs: oplogs,
 	}

--- a/service/protocol_sync_pending_oplog.go
+++ b/service/protocol_sync_pending_oplog.go
@@ -32,13 +32,18 @@ func (pm *BaseProtocolManager) SyncPendingOplog(
 	handleFailedOplog func(oplog *BaseOplog) error,
 	syncMsg OpType,
 ) error {
-	oplogs, failedOplogs, err := pm.GetPendingOplogs(setDB)
+
+	oplogs, failedOplogs, err := pm.GetPendingOplogs(setDB, peer, false)
 	if err != nil {
 		return nil
 	}
 
 	err = HandleFailedOplogs(failedOplogs, setDB, handleFailedOplog)
 	if err != nil {
+		return nil
+	}
+
+	if peer == nil {
 		return nil
 	}
 

--- a/service/protocol_sync_pending_oplog_ack.go
+++ b/service/protocol_sync_pending_oplog_ack.go
@@ -42,7 +42,7 @@ func (pm *BaseProtocolManager) SyncPendingOplogAck(
 		return err
 	}
 
-	oplogs, failedOplogs, err := pm.GetPendingOplogs(setDB)
+	oplogs, failedOplogs, err := pm.GetPendingOplogs(setDB, peer, false)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
1. broadcast all pending logs in create-object to improve the order of creating-objects.
2. remove blocks and obj if I am not the creator of the object.
3. set only the fail-flag if I am the creator of the object.