### PR TITLE
Do not register keyInfo with empty KeyBytes.

### DIFF
--- a/service/op_key_utils.go
+++ b/service/op_key_utils.go
@@ -168,17 +168,15 @@ func (k *KeyInfo) Unmarshal(data []byte) error {
 		return err
 	}
 
-	if k.KeyBytes == nil {
-		log.Error("KeyInfo.Unmarshal: invalid data", "data", data)
-		return ErrInvalidKeyInfo
-	}
+	// it's possible that k.KeyBytes is nil because of the init-key.
+	if k.KeyBytes != nil {
+		k.Key, err = crypto.ToECDSA(k.KeyBytes)
+		if err != nil {
+			return err
+		}
 
-	k.Key, err = crypto.ToECDSA(k.KeyBytes)
-	if err != nil {
-		return err
+		k.PubKeyBytes = crypto.FromECDSAPub(&k.Key.PublicKey)
 	}
-
-	k.PubKeyBytes = crypto.FromECDSAPub(&k.Key.PublicKey)
 
 	return nil
 }


### PR DESCRIPTION
It's possible that there is no keyBytes when keyInfo is in pending status. 
Do not register keyInfo with empty KeyBytes.

intends to fix #178 