### PR TITLE
Defenesive programming for merkle and op-key.

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -194,7 +194,7 @@ func (n *Node) Start() error {
 		// Construct and save the service
 		n.log.Info("in serviceFunc-loop: to constructor", "services", services)
 		service, err := constructor(ctx)
-		n.log.Info("in serviceFunc-loop", "services", services, "service", service, "e", err)
+		// n.log.Info("in serviceFunc-loop", "services", services, "service", service, "e", err)
 		if err != nil {
 			log.Error("in serviceFunc-loop: unable to constructor", "e", err)
 			return err
@@ -224,7 +224,7 @@ func (n *Node) Start() error {
 	started := []reflect.Type{}
 	for kind, service := range services {
 		// Start the next service, stopping all previous upon failure
-		n.log.Info("to service.Start", "kind", kind, "service", service)
+		// n.log.Info("to service.Start", "kind", kind, "service", service)
 
 		if err := service.Start(running); err != nil {
 			n.log.Error("something went wrong with service-starting", "e", err, "service", service)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -291,11 +291,11 @@ func (p *Peer) handle(msg Msg) error {
 	//p.log.Info("handle (msg): start", "msg", msg)
 	switch {
 	case msg.Code == pingMsg:
-		p.log.Info("handle (msg): pingMsg")
+		p.log.Debug("handle (msg): pingMsg")
 		msg.Discard()
 		go SendItems(p.rw, pongMsg)
 	case msg.Code == pongMsg:
-		p.log.Info("handle (msg): pongMsg")
+		p.log.Debug("handle (msg): pongMsg")
 		return msg.Discard()
 	case msg.Code == discMsg:
 		var reason [1]DiscReason

--- a/pttdb/globals.go
+++ b/pttdb/globals.go
@@ -36,8 +36,7 @@ const (
 )
 
 var (
-	DBMetaPostfix = []byte("mt")
-	dbLastKey     = []byte{255}
+	dbLastKey = []byte{255}
 )
 
 const (

--- a/pttdb/ldb_database.go
+++ b/pttdb/ldb_database.go
@@ -145,7 +145,7 @@ func (db *LDBDatabase) TryPut(key []byte, value []byte, updateTS types.Timestamp
 	}
 
 	if updateTS.IsLess(d.UpdateTS) {
-		log.Warn("updateTS < d.UpdateTS", "updateTS", updateTS, "d.UpdateTS", d.UpdateTS)
+		log.Warn("updateTS < d.UpdateTS", "updateTS", updateTS, "d.UpdateTS", d.UpdateTS, "key", key)
 		return v, ErrInvalidUpdateTS
 	}
 

--- a/service/globals.go
+++ b/service/globals.go
@@ -276,8 +276,9 @@ var (
 	DBMerkleGenerateTimePrefix = []byte(".mtgt")
 	DBMerkleSyncTimePrefix     = []byte(".mtst")
 	DBMerkleFailSyncTimePrefix = []byte(".mtft")
-	DBMerkleToUpdatePostfix    = []byte("mt")
-	DBMerkleUpdatingPostfix    = []byte("mT")
+	DBMerkleMetaPostfix        = []byte("mt")
+	DBMerkleToUpdatePostfix    = []byte("Mt")
+	DBMerkleUpdatingPostfix    = []byte("MT")
 
 	OffsetMerkleSyncTime int64 = 3600 // validate until 2-hr ago, and sync with data starting 2-hr ago.
 

--- a/service/protocol_create_op_key_logs.go
+++ b/service/protocol_create_op_key_logs.go
@@ -109,5 +109,7 @@ func (pm *BaseProtocolManager) postfailedCreateOpKey(theOpKey Object, oplog *Bas
 		return ErrInvalidData
 	}
 
-	return pm.RemoveOpKeyFromHash(opKey.Hash, false, true, true)
+	opKey.Delete(true)
+
+	return pm.RemoveOpKeyFromHash(opKey.Hash, false, false, false)
 }

--- a/service/protocol_force_sync_oplog.go
+++ b/service/protocol_force_sync_oplog.go
@@ -31,10 +31,14 @@ func (pm *BaseProtocolManager) ForceSyncOplog(
 	fromTS types.Timestamp,
 	toTS types.Timestamp,
 
+	merkle *Merkle,
+
 	forceSyncOplogMsg OpType,
 
 	peer *PttPeer,
 ) error {
+
+	merkle.ForceSaveSyncTime(fromTS)
 
 	data := &ForceSyncOplog{
 		FromTS: fromTS,

--- a/service/protocol_identify_peer.go
+++ b/service/protocol_identify_peer.go
@@ -43,6 +43,7 @@ func (pm *BaseProtocolManager) IdentifyPeer(peer *PttPeer) {
 	ptt := pm.Ptt()
 	data, err := ptt.IdentifyPeer(pm.Entity().GetID(), pm.QuitSync(), peer)
 	if err != nil {
+		log.Warn("IdentifyPeer: unable to ptt.IdentifyPeer", "e", err, "p", peer, "userID", peer.UserID)
 		return
 	}
 
@@ -80,7 +81,10 @@ func (p *BasePtt) IdentifyPeer(entityID *types.PttID, quitSync chan struct{}, pe
 	}
 
 	// 2. init info in peer
-	peer.InitID(entityID, salt, quitSync)
+	err = peer.InitID(entityID, salt, quitSync)
+	if err != nil {
+		return nil, err
+	}
 
 	// 3. send data to peer
 	data := &IdentifyPeer{

--- a/service/protocol_identify_peer_ack.go
+++ b/service/protocol_identify_peer_ack.go
@@ -122,7 +122,7 @@ HandleIdentifyPeerAck
 func (p *BasePtt) HandleIdentifyPeerAck(entityID *types.PttID, data *IdentifyPeerAck, peer *PttPeer) error {
 
 	if !reflect.DeepEqual(peer.IDChallenge[:], data.AckChallenge[:types.SizeSalt]) {
-		log.Warn("HandleIdentifyPeerAck: unable to match challenge")
+		log.Warn("HandleIdentifyPeerAck: unable to match challenge", "peer", peer.IDChallenge, "data", data.AckChallenge, "peer", peer)
 		return ErrInvalidData
 	}
 

--- a/service/protocol_manager.go
+++ b/service/protocol_manager.go
@@ -712,10 +712,11 @@ func (pm *BaseProtocolManager) Prestart() error {
 	// op-key
 	opKeyInfos, err := pm.loadOpKeyInfos()
 	if err != nil {
-		return err
+		log.Error("Prestart: unable to loadOpKeyInfos", "e", err)
+		opKeyInfos = make([]*KeyInfo, 0)
 	}
 
-	log.Debug("Prestart: after loadOpKeyInfos", "opKeyInfos", opKeyInfos)
+	log.Debug("Prestart: after loadOpKeyInfos", "opKeyInfos", opKeyInfos, "e", err)
 
 	pm.registerOpKeys(opKeyInfos, false)
 
@@ -737,6 +738,7 @@ func (pm *BaseProtocolManager) Prestart() error {
 		err = pm.loadMyMemberLog()
 		log.Debug("Prestart: after loadMyMemberLog", "e", err, "service", pm.Entity().Service().Name())
 		if err != nil {
+			log.Error("Prestart: unable to loadMyMemberLog", "e", err, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 			return err
 		}
 	}

--- a/service/protocol_sync_oplog_invalid_ack.go
+++ b/service/protocol_sync_oplog_invalid_ack.go
@@ -57,7 +57,7 @@ func (pm *BaseProtocolManager) SyncOplogInvalidAck(
 	isToSyncPeer := pm.syncOplogInvalidAckIsToSyncPeer(peer, theirSyncTS, mySyncTS)
 
 	if isToSyncPeer {
-		return pm.ForceSyncOplog(fromSyncTS, toSyncTS, forceSyncOplogMsg, peer)
+		return pm.ForceSyncOplog(fromSyncTS, toSyncTS, merkle, forceSyncOplogMsg, peer)
 	}
 
 	data := &SyncOplogAckInvalid{
@@ -163,7 +163,7 @@ func (pm *BaseProtocolManager) HandleSyncOplogInvalidAck(
 
 	// 1. the peer is PeerTypeMe or the peer is master
 	if isMe || isPeerMaster {
-		return pm.ForceSyncOplog(data.FromTS, data.ToTS, forceSyncOplogMsg, peer)
+		return pm.ForceSyncOplog(data.FromTS, data.ToTS, merkle, forceSyncOplogMsg, peer)
 	}
 
 	// 2. I am the master and the peer is not master.
@@ -177,7 +177,7 @@ func (pm *BaseProtocolManager) HandleSyncOplogInvalidAck(
 	if lenMasterPeerList > 0 {
 		randIdx := rand.Intn(lenMasterPeerList)
 		masterPeer := masterPeerList[randIdx]
-		return pm.ForceSyncOplog(data.FromTS, data.ToTS, forceSyncOplogMsg, masterPeer)
+		return pm.ForceSyncOplog(data.FromTS, data.ToTS, merkle, forceSyncOplogMsg, masterPeer)
 	}
 
 	// 4. try to connect the master-node.

--- a/service/service_protocol_manager_utils_entity.go
+++ b/service/service_protocol_manager_utils_entity.go
@@ -78,7 +78,7 @@ func (b *BaseServiceProtocolManager) StartEntities() error {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	log.Info("StartEntities", "service", b.Service().Name(), "entities", b.entities)
+	// log.Info("StartEntities", "service", b.Service().Name(), "entities", b.entities)
 
 	var err error
 	for _, entity := range b.entities {
@@ -94,7 +94,7 @@ func (b *BaseServiceProtocolManager) PrestartEntities() error {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	log.Info("PrestartEntities", "entities", b.entities)
+	// log.Info("PrestartEntities", "entities", b.entities)
 	for _, entity := range b.entities {
 		err := entity.Prestart()
 		if err != nil {


### PR DESCRIPTION
1. merkle.ForceSaveSyncTime.
2. defensive programming for merkle.SaveSyncTime.
3. DBMerkleMetaPostfix.
4. merkle.ForceSaveSyncTime to fromTS in ForceSyncOplog.

5. defensive programming for IdentifyPeer.
6. defensive programming for opKeyInfos in in pm.Prestart