### PR TITLE
Fix several issues in delete-rejoin.

### DIFF
--- a/e2e/friend_delete_member1_test.go
+++ b/e2e/friend_delete_member1_test.go
@@ -415,13 +415,11 @@ func TestFriendDeleteMember1(t *testing.T) {
 	marshaled, _ = board1_13_1.ID.MarshalText()
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getPeers", "params": ["%v"]}`, string(marshaled))
 
-	/*
-		dataPeers0_19 := &struct {
-			Result []*pkgservice.BackendPeer `json:"result"`
-		}{}
-		testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-		assert.Equal(0, len(dataPeers0_19.Result))
-	*/
+	dataPeers0_19 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`

--- a/e2e/friend_delete_member2_test.go
+++ b/e2e/friend_delete_member2_test.go
@@ -304,7 +304,7 @@ func TestFriendDeleteMember2(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_14_1, t, isDebug)
-	assert.Equal(1, len(dataPeers0_14_1.Result))
+	assert.Equal(0, len(dataPeers0_14_1.Result))
 
 	dataPeers1_14_1 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -452,7 +452,7 @@ func TestFriendDeleteMember2(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-	assert.Equal(1, len(dataPeers0_19.Result))
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`

--- a/e2e/friend_delete_member3_test.go
+++ b/e2e/friend_delete_member3_test.go
@@ -284,6 +284,22 @@ func TestFriendDeleteMember3(t *testing.T) {
 	assert.Equal(me0_3.BoardID, board1_13_1.ID)
 	assert.Equal(types.StatusAlive, board1_13_1.Status)
 
+	// 14.0. get peers
+	marshaled, _ = board1_13_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getPeers", "params": ["%v"]}`, string(marshaled))
+
+	dataPeers0_14_0 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataPeers0_14_0, t, isDebug)
+	assert.Equal(1, len(dataPeers0_14_0.Result))
+
+	dataPeers1_14_0 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataPeers1_14_0, t, isDebug)
+	assert.Equal(1, len(dataPeers1_14_0.Result))
+
 	// 14. delete-member
 	t.Logf("14. delete-member")
 	marshaled, _ = board1_13_1.ID.MarshalText()
@@ -304,7 +320,7 @@ func TestFriendDeleteMember3(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_14_1, t, isDebug)
-	assert.Equal(1, len(dataPeers0_14_1.Result))
+	assert.Equal(0, len(dataPeers0_14_1.Result))
 
 	dataPeers1_14_1 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -452,7 +468,7 @@ func TestFriendDeleteMember3(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-	assert.Equal(1, len(dataPeers0_19.Result))
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`

--- a/e2e/friend_delete_member4_test.go
+++ b/e2e/friend_delete_member4_test.go
@@ -424,7 +424,7 @@ func TestFriendDeleteMember4(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_14_1, t, isDebug)
-	assert.Equal(1, len(dataPeers0_14_1.Result))
+	assert.Equal(0, len(dataPeers0_14_1.Result))
 
 	dataPeers1_14_1 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -610,7 +610,7 @@ func TestFriendDeleteMember4(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-	assert.Equal(1, len(dataPeers0_19.Result))
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`

--- a/e2e/friend_leave_board1_test.go
+++ b/e2e/friend_leave_board1_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -380,27 +381,25 @@ func TestFriendLeaveBoard1(t *testing.T) {
 	marshaled, _ = board1_13_1.ID.MarshalText()
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getMemberList", "params": ["%v", "", 0, 2]}`, string(marshaled))
 
-	/*
-		dataMembers0_19 := &struct {
-			Result []*pkgservice.Member `json:"result"`
-		}{}
-		testListCore(t0, bodyString, dataMembers0_19, t, isDebug)
-		assert.Equal(2, len(dataMembers0_19.Result))
-		member0_19_0 := dataMembers0_19.Result[0]
-		member0_19_1 := dataMembers0_19.Result[1]
-		var member0_19_me *pkgservice.Member
-		var member0_19_other *pkgservice.Member
-		if reflect.DeepEqual(member0_19_0.ID, me0_1.ID) {
-			member0_19_me = member0_19_0
-			member0_19_other = member0_19_1
-		} else {
-			member0_19_me = member0_19_1
-			member0_19_other = member0_19_0
-		}
+	dataMembers0_19 := &struct {
+		Result []*pkgservice.Member `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataMembers0_19, t, isDebug)
+	assert.Equal(2, len(dataMembers0_19.Result))
+	member0_19_0 := dataMembers0_19.Result[0]
+	member0_19_1 := dataMembers0_19.Result[1]
+	var member0_19_me *pkgservice.Member
+	var member0_19_other *pkgservice.Member
+	if reflect.DeepEqual(member0_19_0.ID, me0_1.ID) {
+		member0_19_me = member0_19_0
+		member0_19_other = member0_19_1
+	} else {
+		member0_19_me = member0_19_1
+		member0_19_other = member0_19_0
+	}
 
-		assert.Equal(types.StatusAlive, member0_19_me.Status)
-		assert.Equal(types.StatusDeleted, member0_19_other.Status)
-	*/
+	assert.Equal(types.StatusAlive, member0_19_me.Status)
+	assert.Equal(types.StatusDeleted, member0_19_other.Status)
 
 	dataMembers1_19 := &struct {
 		Result []*pkgservice.Member `json:"result"`
@@ -416,13 +415,11 @@ func TestFriendLeaveBoard1(t *testing.T) {
 	marshaled, _ = board1_13_1.ID.MarshalText()
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getPeers", "params": ["%v"]}`, string(marshaled))
 
-	/*
-		dataPeers0_19 := &struct {
-			Result []*pkgservice.BackendPeer `json:"result"`
-		}{}
-		testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-		assert.Equal(0, len(dataPeers0_19.Result))
-	*/
+	dataPeers0_19 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`

--- a/e2e/friend_leave_board3_test.go
+++ b/e2e/friend_leave_board3_test.go
@@ -302,7 +302,7 @@ func TestFriendLeaveBoard3(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_14_1, t, isDebug)
-	assert.Equal(1, len(dataPeers0_14_1.Result))
+	assert.Equal(0, len(dataPeers0_14_1.Result))
 
 	dataPeers1_14_1 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -450,7 +450,7 @@ func TestFriendLeaveBoard3(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-	assert.Equal(1, len(dataPeers0_19.Result))
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`

--- a/e2e/friend_leave_board4_test.go
+++ b/e2e/friend_leave_board4_test.go
@@ -422,7 +422,7 @@ func TestFriendLeaveBoard4(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_14_1, t, isDebug)
-	assert.Equal(1, len(dataPeers0_14_1.Result))
+	assert.Equal(0, len(dataPeers0_14_1.Result))
 
 	dataPeers1_14_1 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -608,7 +608,7 @@ func TestFriendLeaveBoard4(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-	assert.Equal(1, len(dataPeers0_19.Result))
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -634,6 +634,23 @@ func TestFriendLeaveBoard4(t *testing.T) {
 
 	// sleep
 	time.Sleep(TimeSleepRestart)
+
+	// 22.0. sync.
+	t.Logf("22.0. force sync")
+	marshaled, _ = board1_13_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_forceSync", "params": ["%v"]}`, string(marshaled))
+
+	bool0_22_0 := false
+	testCore(t0, bodyString, &bool0_22_0, t, isDebug)
+	assert.Equal(true, bool0_22_0)
+
+	time.Sleep(TimeSleepDefault)
+
+	bool1_22_0 := false
+	testCore(t1, bodyString, &bool1_22_0, t, isDebug)
+	assert.Equal(true, bool1_22_0)
+
+	time.Sleep(TimeSleepDefault)
 
 	// 23. get board list
 	t.Logf("23. get board list")

--- a/e2e/friend_leave_board5_test.go
+++ b/e2e/friend_leave_board5_test.go
@@ -422,7 +422,7 @@ func TestFriendLeaveBoard5(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_14_1, t, isDebug)
-	assert.Equal(1, len(dataPeers0_14_1.Result))
+	assert.Equal(0, len(dataPeers0_14_1.Result))
 
 	dataPeers1_14_1 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -608,7 +608,7 @@ func TestFriendLeaveBoard5(t *testing.T) {
 		Result []*pkgservice.BackendPeer `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataPeers0_19, t, isDebug)
-	assert.Equal(1, len(dataPeers0_19.Result))
+	assert.Equal(0, len(dataPeers0_19.Result))
 
 	dataPeers1_19 := &struct {
 		Result []*pkgservice.BackendPeer `json:"result"`
@@ -634,6 +634,23 @@ func TestFriendLeaveBoard5(t *testing.T) {
 
 	// sleep
 	time.Sleep(TimeSleepRestart)
+
+	// 22.0. sync.
+	t.Logf("22.0. force sync")
+	marshaled, _ = board1_13_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_forceSync", "params": ["%v"]}`, string(marshaled))
+
+	bool0_22_0 := false
+	testCore(t0, bodyString, &bool0_22_0, t, isDebug)
+	assert.Equal(true, bool0_22_0)
+
+	time.Sleep(TimeSleepDefault)
+
+	bool1_22_0 := false
+	testCore(t1, bodyString, &bool1_22_0, t, isDebug)
+	assert.Equal(true, bool1_22_0)
+
+	time.Sleep(TimeSleepDefault)
 
 	// 23. get board list
 	t.Logf("23. get board list")

--- a/pttdb/ldb_database.go
+++ b/pttdb/ldb_database.go
@@ -207,7 +207,7 @@ func (db *LDBDatabase) TryRLockMap(key []byte) error {
 		return ErrBusy
 	}
 
-	log.Debug("after TryRLockMap", "i", i, "ok", ok)
+	log.Debug("after TryRLockMap (pass lock)", "i", i, "ok", ok)
 
 	if !ok {
 		db.lockMap[mapKey] = 0

--- a/service/protocol_add_master_logs.go
+++ b/service/protocol_add_master_logs.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func (pm *BaseProtocolManager) handleAddMasterLog(oplog *BaseOplog, info *ProcessPersonInfo) ([]*BaseOplog, error) {
@@ -27,7 +28,10 @@ func (pm *BaseProtocolManager) handleAddMasterLog(oplog *BaseOplog, info *Proces
 
 	opData := &MasterOpCreateMaster{}
 
-	if oplog.PreLogID == nil {
+	person.SetID(oplog.ObjID)
+	err := person.GetByID(false)
+
+	if err == leveldb.ErrNotFound {
 		return pm.HandleCreatePersonLog(
 			oplog,
 			person,
@@ -57,7 +61,10 @@ func (pm *BaseProtocolManager) handlePendingAddMasterLog(oplog *BaseOplog, info 
 
 	opData := &MasterOpCreateMaster{}
 
-	if oplog.PreLogID == nil {
+	person.SetID(oplog.ObjID)
+	err := person.GetByID(false)
+
+	if err == leveldb.ErrNotFound {
 		return pm.HandlePendingCreatePersonLog(
 			oplog,
 			person,

--- a/service/protocol_add_member_logs.go
+++ b/service/protocol_add_member_logs.go
@@ -19,6 +19,7 @@ package service
 import (
 	"github.com/ailabstw/go-pttai/common/types"
 	"github.com/ailabstw/go-pttai/log"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func (pm *BaseProtocolManager) handleAddMemberLog(oplog *BaseOplog, info *ProcessPersonInfo) ([]*BaseOplog, error) {
@@ -28,9 +29,10 @@ func (pm *BaseProtocolManager) handleAddMemberLog(oplog *BaseOplog, info *Proces
 
 	opData := &MemberOpAddMember{}
 
-	log.Debug("handleAddMemberLog: start", "oplog.PreLogID", oplog.PreLogID)
-
-	if oplog.PreLogID == nil {
+	person.SetID(oplog.ObjID)
+	err := person.GetByID(false)
+	log.Debug("handleAddMemberLog: after GetByID", "id", oplog.ObjID, "e", err, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	if err == leveldb.ErrNotFound {
 		return pm.HandleCreatePersonLog(
 			oplog,
 			person,
@@ -59,7 +61,10 @@ func (pm *BaseProtocolManager) handlePendingAddMemberLog(oplog *BaseOplog, info 
 
 	opData := &MemberOpAddMember{}
 
-	if oplog.PreLogID == nil {
+	person.SetID(oplog.ObjID)
+	err := person.GetByID(false)
+
+	if err == leveldb.ErrNotFound {
 		return pm.HandlePendingCreatePersonLog(
 			oplog,
 			person,

--- a/service/protocol_delete_member.go
+++ b/service/protocol_delete_member.go
@@ -81,11 +81,14 @@ func (pm *BaseProtocolManager) postdeleteMember(
 	if reflect.DeepEqual(myID, oplog.ObjID) {
 		pm.myMemberLog = OplogToMemberOplog(oplog)
 		entity.SetStatus(types.StatusDeleted)
+		entity.SetUpdateTS(pm.myMemberLog.UpdateTS)
 		entity.Save(false)
 
 		if pm.postdelete != nil {
 			pm.postdelete(opData, true)
 		}
+	} else {
+		pm.UnregisterPeerByOtherUserID(oplog.ObjID, true, false)
 	}
 
 	return nil

--- a/service/protocol_delete_person.go
+++ b/service/protocol_delete_person.go
@@ -83,7 +83,7 @@ func (pm *BaseProtocolManager) DeletePerson(
 		return err
 	}
 	oplog := theOplog.GetBaseOplog()
-	oplog.PreLogID = origPerson.GetLogID()
+	// oplog.PreLogID = origPerson.GetLogID()
 
 	err = pm.SignOplog(oplog)
 	if err != nil {
@@ -117,7 +117,7 @@ func (pm *BaseProtocolManager) DeletePerson(
 			merkle,
 
 			setLogDB,
-			postdelete,
+			nil,
 			nil,
 		)
 	} else {
@@ -150,6 +150,11 @@ func (pm *BaseProtocolManager) DeletePerson(
 	log.Debug("DeletePerson: to broadcastLog", "entity", pm.Entity().GetID())
 
 	broadcastLog(oplog)
+
+	// postdelete
+	if oplogStatus >= types.StatusDeleted && postdelete != nil {
+		postdelete(oplog.ObjID, oplog, origPerson, opData)
+	}
 
 	return nil
 }

--- a/service/protocol_delete_person_logs.go
+++ b/service/protocol_delete_person_logs.go
@@ -65,6 +65,7 @@ func (pm *BaseProtocolManager) HandleDeletePersonLog(
 		return nil, err
 	}
 
+	log.Debug("HandleDeletePersonLog: start", "oplog.TS", oplog.UpdateTS, "person.UpdateTS", origPerson.GetUpdateTS())
 	if oplog.UpdateTS.IsLess(origPerson.GetUpdateTS()) {
 		return nil, ErrNewerOplog
 	}
@@ -102,7 +103,7 @@ func (pm *BaseProtocolManager) HandleDeletePersonLog(
 		merkle,
 
 		setLogDB,
-		postdelete,
+		nil,
 		updateDeleteInfo,
 	)
 

--- a/service/protocol_handle_member_oplog.go
+++ b/service/protocol_handle_member_oplog.go
@@ -85,6 +85,12 @@ func (pm *BaseProtocolManager) postprocessMemberOplogs(processInfo ProcessInfo, 
 
 	pm.broadcastMemberOplogsCore(toBroadcastLogs)
 
+	if !isPending {
+		for _, eachLog := range deleteInfos {
+			pm.postdeleteMember(eachLog.ObjID, eachLog, nil, nil)
+		}
+	}
+
 	return nil
 }
 

--- a/service/protocol_manager_utils_entity.go
+++ b/service/protocol_manager_utils_entity.go
@@ -65,7 +65,7 @@ func (pm *BaseProtocolManager) DefaultPostdeleteEntity(opData OpData, isForce bo
 	pm.CleanMasterOplog()
 
 	// member
-	pm.CleanMember()
+	pm.CleanMember(true)
 	log.Debug("DefaultPostdeleteEntity: to CleanMemberOplog", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 	pm.CleanMemberOplog(true)
 
@@ -80,8 +80,10 @@ func (pm *BaseProtocolManager) DefaultPostdeleteEntity(opData OpData, isForce bo
 }
 
 func (pm *BaseProtocolManager) FullCleanLog() {
-	log.Debug("FullCleanLog: to CleanMemberOplog", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	log.Debug("FullCleanLog: start", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	pm.CleanMember(false)
 	pm.CleanMemberOplog(false)
-	log.Debug("FullCleanLog: to CleanLog0", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 	pm.CleanLog0(false)
+
+	log.Debug("FullCleanLog: end", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 }

--- a/service/protocol_manager_utils_member.go
+++ b/service/protocol_manager_utils_member.go
@@ -119,13 +119,17 @@ func (pm *BaseProtocolManager) loadMyMemberLog() error {
 	return nil
 }
 
-func (pm *BaseProtocolManager) CleanMember() error {
+func (pm *BaseProtocolManager) CleanMember(isRetainMe bool) error {
 	members, err := pm.GetMemberList(nil, 0, pttdb.ListOrderNext, false)
 	if err != nil {
 		return err
 	}
 
+	myID := pm.Ptt().GetMyEntity().GetID()
 	for _, member := range members {
+		if isRetainMe && reflect.DeepEqual(myID, member.ID) {
+			continue
+		}
 		member.Delete(false)
 	}
 

--- a/service/protocol_manager_utils_peer.go
+++ b/service/protocol_manager_utils_peer.go
@@ -103,7 +103,7 @@ func (pm *BaseProtocolManager) UnregisterPeer(peer *PttPeer, isForceReset bool, 
 		return nil
 	}
 
-	pm.Ptt().FinishIdentifyPeer(peer, isPttLocked, isForceReset)
+	pm.Ptt().ResetPeerType(peer, isPttLocked, isForceReset)
 
 	return nil
 }
@@ -123,7 +123,7 @@ func (pm *BaseProtocolManager) UnregisterPeerByOtherUserID(id *types.PttID, isRe
 		return nil
 	}
 
-	pm.Ptt().FinishIdentifyPeer(peer, isPttLocked, isResetPeerType)
+	pm.Ptt().ResetPeerType(peer, isPttLocked, isResetPeerType)
 
 	return nil
 }

--- a/service/protocol_manager_utils_sync.go
+++ b/service/protocol_manager_utils_sync.go
@@ -39,8 +39,11 @@ looping:
 				break looping
 			}
 
+			log.Debug("PMSync: NewPeerCh: start", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
 			pm.SyncOpKeyOplog(peer, SyncOpKeyOplogMsg)
 			err = pm.Sync(peer)
+			log.Debug("PMSync: NewPeerCh: after pm.Sync", "entity", pm.Entity(), "peer", peer, "e", err)
 			if err != nil {
 				log.Error("unable to Sync after newPeer", "e", err, "peer", peer)
 			}

--- a/service/protocol_update_person.go
+++ b/service/protocol_update_person.go
@@ -61,7 +61,7 @@ func (pm *BaseProtocolManager) UpdatePerson(
 		return nil, nil, err
 	}
 	oplog := theOplog.GetBaseOplog()
-	oplog.PreLogID = origPerson.GetLogID()
+	// oplog.PreLogID = origPerson.GetLogID()
 
 	err = pm.SignOplog(oplog)
 	if err != nil {

--- a/service/ptt.go
+++ b/service/ptt.go
@@ -45,6 +45,8 @@ type Ptt interface {
 	FinishIdentifyPeer(peer *PttPeer, isLocked bool, isResetPeerType bool) error
 	SetupPeer(peer *PttPeer, peerType PeerType, isLocked bool) error
 
+	ResetPeerType(peer *PttPeer, isLocked bool, isResetPeerType bool) error
+
 	NoMorePeers() chan struct{}
 
 	AddDial(nodeID *discover.NodeID, opKey *common.Address, peerType PeerType) error

--- a/service/ptt_utils_peer.go
+++ b/service/ptt_utils_peer.go
@@ -141,6 +141,36 @@ func (p *BasePtt) FinishIdentifyPeer(peer *PttPeer, isLocked bool, isResetPeerTy
 	return p.SetupPeer(peer, peerType, true)
 }
 
+func (p *BasePtt) ResetPeerType(peer *PttPeer, isLocked bool, isForceReset bool) error {
+
+	if !isLocked {
+		p.peerLock.Lock()
+		defer p.peerLock.Unlock()
+	}
+
+	log.Debug("ResetPeerType", "peer", peer, "userID", peer.UserID)
+
+	if peer.UserID == nil {
+		return ErrPeerUserID
+	}
+
+	if isForceReset {
+		p.SetPeerType(peer, PeerTypeRandom, true, true)
+	}
+
+	peerType, err := p.determinePeerTypeFromAllEntities(peer, true)
+	if err != nil {
+		return err
+	}
+
+	err = p.addPeerKnownUserID(peer, peerType, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (p *BasePtt) determinePeerTypeFromAllEntities(peer *PttPeer, isLocked bool) (PeerType, error) {
 	if !isLocked {
 		p.peerLock.Lock()


### PR DESCRIPTION
intends to fix #198 

1. no lock in CleanMemberLog and CleanLog0
2. CleanMember with isRetainMe
3. ptt.ResetPeerType in pm.UnregsterPeer.
4. do postdeleteMember after broadcast log.
5. no PreLogID for UpdatePersonLog and DeletePersonLog.
6. saveNewObjectWithOplog in UpdatePerson.
7. handleAddMasterLog and handleAddMemberLog check person exists, not PreLogID