### PR TITLE
ptt.peerLock focuses on peers only.

### DIFF
--- a/account/protocol_handle_user_oplog.go
+++ b/account/protocol_handle_user_oplog.go
@@ -153,7 +153,9 @@ func (pm *ProtocolManager) postprocessUserOplogs(processInfo pkgservice.ProcessI
 	pm.SyncNameCard(SyncUpdateNameCardMsg, updateNameCardIDs, peer)
 
 	// broadcast
-	pm.broadcastUserOplogsCore(toBroadcastLogs)
+	if isPending {
+		pm.broadcastUserOplogsCore(toBroadcastLogs)
+	}
 
 	return
 }

--- a/cmd/gptt/gptt.go
+++ b/cmd/gptt/gptt.go
@@ -40,7 +40,7 @@ import (
 func gptt(ctx *cli.Context) error {
 	utils.SetLogging(ctx)
 
-	log.Info("Ptt.ai: Hello world!")
+	log.Info("PTT.ai: Hello world!")
 
 	// Load Config
 	cfg, err := loadConfig(ctx)
@@ -107,7 +107,7 @@ func gptt(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Info("Ptt.ai: see u later～")
+	log.Info("PTT.ai: see u later～")
 
 	return nil
 }

--- a/content/protocol_handle_board_oplog.go
+++ b/content/protocol_handle_board_oplog.go
@@ -227,9 +227,9 @@ func (pm *ProtocolManager) postprocessBoardOplogs(processInfo pkgservice.Process
 		if err != nil {
 			return
 		}
-	}
 
-	pm.broadcastBoardOplogsCore(toBroadcastLogs)
+		pm.broadcastBoardOplogsCore(toBroadcastLogs)
+	}
 
 	// post-delete-board
 	if !isPending && len(info.BoardInfo) > 0 {

--- a/e2e/friend_delete_board2_test.go
+++ b/e2e/friend_delete_board2_test.go
@@ -663,7 +663,7 @@ func TestFriendDeleteBoard2(t *testing.T) {
 	time.Sleep(TimeSleepDefault)
 
 	// 47.2 t1 restart
-	startNode(t, 1, 0)
+	startNode(t, 1, 0, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/friend_delete_friend2_test.go
+++ b/e2e/friend_delete_friend2_test.go
@@ -350,7 +350,7 @@ func TestFriendDeleteFriend2(t *testing.T) {
 	time.Sleep(TimeSleepRestart)
 
 	// 13.1 t1 restart
-	startNode(t, 1, 0)
+	startNode(t, 1, 0, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/friend_force_sync_member_test.go
+++ b/e2e/friend_force_sync_member_test.go
@@ -435,7 +435,7 @@ func TestFriendForceSyncMember(t *testing.T) {
 	// 22.0 get merkle
 
 	// 21. restart t0
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/friend_leave_board5_test.go
+++ b/e2e/friend_leave_board5_test.go
@@ -856,7 +856,7 @@ func TestFriendLeaveBoard5(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// 32. start
-	startNode(t, 1, 0)
+	startNode(t, 1, 0, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/friend_member_request_op_key_test.go
+++ b/e2e/friend_member_request_op_key_test.go
@@ -396,7 +396,7 @@ func TestFriendMemberRequestOpKey(t *testing.T) {
 	offsetSecond := int64(86400 * 10)
 
 	// 20. start
-	startNode(t, 1, offsetSecond)
+	startNode(t, 1, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 
@@ -411,7 +411,7 @@ func TestFriendMemberRequestOpKey(t *testing.T) {
 	assert.Equal(0, len(dataGetKeyInfos1_21.Result))
 
 	// 22. start
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/friend_msg_fail_test.go
+++ b/e2e/friend_msg_fail_test.go
@@ -444,7 +444,7 @@ func TestFriendMsgFail(t *testing.T) {
 	assert.Equal(types.StatusFailed, msg1_42.Status)
 
 	// 99. start-node
-	startNode(t, 0, 0)
+	startNode(t, 0, 0, false)
 
 	// wait 15 seconds
 

--- a/e2e/friend_msg_restart_test.go
+++ b/e2e/friend_msg_restart_test.go
@@ -443,7 +443,7 @@ func TestFriendMsgRestart(t *testing.T) {
 	assert.Equal(types.StatusPending, msg1_42.Status)
 
 	// 43. start-node
-	startNode(t, 0, 0)
+	startNode(t, 0, 0, false)
 
 	// wait 15 seconds
 

--- a/e2e/friend_revoke_op_key_test.go
+++ b/e2e/friend_revoke_op_key_test.go
@@ -392,7 +392,7 @@ func TestFriendRevokeOpKey(t *testing.T) {
 	opKey0_19 := dataOpKeyList0_19.Result[0]
 
 	// 20. restart node 1
-	startNode(t, 1, offsetSecond)
+	startNode(t, 1, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/me_expire_op_key_test.go
+++ b/e2e/me_expire_op_key_test.go
@@ -211,7 +211,7 @@ func TestMeExpireOpKey(t *testing.T) {
 
 	// 12. restart
 	offsetSecond := int64(86400 * 8)
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	// 13. test-error
 	err0_13 := testError("http://127.0.0.1:9450")

--- a/e2e/multi_device3_force_sync_article1_test.go
+++ b/e2e/multi_device3_force_sync_article1_test.go
@@ -739,7 +739,7 @@ func TestMultiDevice3ForceSyncArticle1(t *testing.T) {
 	assert.Equal(article1, dataGetArticleBlockList2_47.Result[1].Buf)
 
 	// 48. restart t0
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/multi_device3_force_sync_article2_test.go
+++ b/e2e/multi_device3_force_sync_article2_test.go
@@ -751,12 +751,12 @@ func TestMultiDevice3ForceSyncArticle2(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// 48. restart t0
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 
 	// 48.1. restart t1
-	startNode(t, 1, offsetSecond)
+	startNode(t, 1, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/multi_device3_force_sync_article3_test.go
+++ b/e2e/multi_device3_force_sync_article3_test.go
@@ -751,12 +751,12 @@ func TestMultiDevice3ForceSyncArticle3(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// 48. restart t0
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 
 	// 48.1. restart t1
-	startNode(t, 1, offsetSecond)
+	startNode(t, 1, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/multi_device3_force_sync_article4_test.go
+++ b/e2e/multi_device3_force_sync_article4_test.go
@@ -731,12 +731,12 @@ func TestMultiDevice3ForceSyncArticle4(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// 48. restart t0
-	startNode(t, 0, offsetSecond)
+	startNode(t, 0, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 
 	// 48.1. restart t1
-	startNode(t, 1, offsetSecond)
+	startNode(t, 1, offsetSecond, false)
 
 	time.Sleep(TimeSleepRestart)
 

--- a/e2e/multi_device_sync_after_device_sleep_test.go
+++ b/e2e/multi_device_sync_after_device_sleep_test.go
@@ -124,7 +124,7 @@ func TestMultiDeviceSyncAfterDeviceSleep(t *testing.T) {
 	assert.NotEqual(nil, err0_5_2)
 
 	// 8.4 start-node
-	startNode(t, 0, 0)
+	startNode(t, 0, 0, false)
 
 	// wait 15 seconds
 	time.Sleep(15 * time.Second)

--- a/friend/protocol_handle_friend_oplog.go
+++ b/friend/protocol_handle_friend_oplog.go
@@ -112,7 +112,9 @@ func (pm *ProtocolManager) postprocessFriendOplogs(processInfo pkgservice.Proces
 
 	pm.SyncBlock(SyncCreateMessageBlockMsg, blockIDs, peer)
 
-	pm.broadcastFriendOplogsCore(toBroadcastLogs)
+	if isPending {
+		pm.broadcastFriendOplogsCore(toBroadcastLogs)
+	}
 
 	// post-delete-friend
 	if !isPending && len(info.FriendInfo) > 0 {

--- a/me/protocol_handle_me_oplog.go
+++ b/me/protocol_handle_me_oplog.go
@@ -119,9 +119,8 @@ func (pm *ProtocolManager) postprocessMeOplogs(processInfo pkgservice.ProcessInf
 
 	if isPending {
 		toBroadcastLogs = pkgservice.ProcessInfoToBroadcastLogs(info.DeleteMeInfo, toBroadcastLogs)
+		pm.broadcastMeOplogsCore(toBroadcastLogs)
 	}
-
-	pm.broadcastMeOplogsCore(toBroadcastLogs)
 
 	return
 }

--- a/service/errors.go
+++ b/service/errors.go
@@ -24,6 +24,7 @@ import (
 var (
 	ErrAlreadyPrestarted = errors.New("already prestarted")
 	ErrAlreadyStarted    = errors.New("already started")
+	ErrToClose           = errors.New("peer is to close")
 	ErrClosed            = errors.New("peer set is closed")
 	ErrAlreadyRegistered = errors.New("peer is already registered")
 	ErrNotRegistered     = errors.New("peer is not registered")

--- a/service/protocol_identify_peer.go
+++ b/service/protocol_identify_peer.go
@@ -74,14 +74,8 @@ func (pm *BaseProtocolManager) HandleIdentifyPeer(dataBytes []byte, peer *PttPee
 
 func (p *BasePtt) IdentifyPeer(entityID *types.PttID, quitSync chan struct{}, peer *PttPeer) (*IdentifyPeer, error) {
 
-	// 1. generate salt
-	salt, err := types.NewSalt()
-	if err != nil {
-		return nil, err
-	}
-
 	// 2. init info in peer
-	err = peer.InitID(entityID, salt, quitSync)
+	salt, err := peer.InitID(entityID, quitSync)
 	if err != nil {
 		return nil, err
 	}

--- a/service/protocol_identify_peer_with_my_id.go
+++ b/service/protocol_identify_peer_with_my_id.go
@@ -39,7 +39,8 @@ func (p *BasePtt) IdentifyPeerWithMyID(peer *PttPeer) error {
 
 	myID := p.myEntity.GetID()
 
-	salt, err := types.NewSalt()
+	peer.ResetInitID()
+	salt, err := peer.InitID(myID, p.quitSync)
 	if err != nil {
 		return err
 	}
@@ -50,7 +51,6 @@ func (p *BasePtt) IdentifyPeerWithMyID(peer *PttPeer) error {
 	}
 
 	peer.IDEntityID = nil
-	peer.InitID(myID, salt, p.quitSync)
 
 	log.Debug("IdentifyPeerWithMyID: to SendDataToPeer", "peer", peer)
 

--- a/service/protocol_manager_utils_peer.go
+++ b/service/protocol_manager_utils_peer.go
@@ -92,7 +92,7 @@ func (pm *BaseProtocolManager) UnregisterPeer(peer *PttPeer, isForceReset bool, 
 
 	err := pm.peers.Unregister(peer, false)
 
-	log.Info("UnregisterPeer: after peers.Unregister", "e", err, "peer", peer, "peerType", peerType, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	log.Info("UnregisterPeer: after peers.Unregister", "e", err, "peer", peer, "peerType", peerType, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name(), "isForceNotReset", isForceNotReset, "isForceReset", isForceReset, "isPttLocked", isPttLocked)
 	if err != nil {
 		return err
 	}

--- a/service/ptt_peer_set.go
+++ b/service/ptt_peer_set.go
@@ -97,6 +97,10 @@ func (ps *PttPeerSet) IsClosed() bool {
 }
 
 func (ps *PttPeerSet) Register(peer *PttPeer, peerType PeerType, isLocked bool) error {
+	if ps.closed {
+		return ErrClosed
+	}
+
 	if !isLocked {
 		ps.Lock()
 		defer ps.Unlock()


### PR DESCRIPTION
1. no peerLock in UnregisterPeerFromEntities.
2. no peerLock in RegisterPeerToEntities.

3. p.wg.Done before p.protoErr <- err in p2p.peer.startProtocols

4. generate salt in PttPeer.InitID
5. PttPeer.ResetInitID

6. Renaming Ptt.ai to PTT.ai