### PR TITLE
Reduce the strictness of Sync-Oplog-Invalid to make the resync smoother.

### DIFF
--- a/account/globals.go
+++ b/account/globals.go
@@ -42,12 +42,17 @@ const (
 	AddPendingUserOplogsMsg
 
 	SyncUserOplogMsg
-	ForceSyncUserOplogMsg
-	ForceSyncUserOplogAckMsg
-	InvalidSyncUserOplogMsg
 	SyncUserOplogAckMsg
 	SyncUserOplogNewOplogsMsg
 	SyncUserOplogNewOplogsAckMsg
+
+	InvalidSyncUserOplogMsg
+
+	ForceSyncUserOplogMsg
+	ForceSyncUserOplogAckMsg
+	ForceSyncUserOplogByMerkleMsg
+	ForceSyncUserOplogByMerkleAckMsg
+	ForceSyncUserOplogByOplogAckMsg
 
 	SyncPendingUserOplogMsg // 50
 	SyncPendingUserOplogAckMsg

--- a/account/protocol_handle_user_oplogs.go
+++ b/account/protocol_handle_user_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncUserOplog(dataBytes []byte, peer *pkgservic
 
 		pm.userOplogMerkle,
 
-		ForceSyncUserOplogMsg,
-		ForceSyncUserOplogAckMsg,
+		ForceSyncUserOplogByMerkleMsg,
+		ForceSyncUserOplogByMerkleAckMsg,
 		InvalidSyncUserOplogMsg,
 		SyncUserOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncUserOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncUserOplogByMerkleAckMsg,
+		ForceSyncUserOplogByOplogAckMsg,
+
+		pm.SetUserDB,
+		pm.SetNewestUserOplog,
+
+		pm.userOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncUserOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncUserOplogByMerkleMsg,
+
+		pm.userOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncUserOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleUserOplogs,
+
+		pm.userOplogMerkle,
 	)
 }
 
@@ -86,14 +123,14 @@ func (pm *ProtocolManager) HandleForceSyncUserOplogAck(dataBytes []byte, peer *p
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncUserOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncUserOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 
 		pm.userOplogMerkle,
-		ForceSyncUserOplogMsg,
+		ForceSyncUserOplogByMerkleMsg,
 	)
 }
 

--- a/account/protocol_manager_utils_handle_message.go
+++ b/account/protocol_manager_utils_handle_message.go
@@ -30,12 +30,14 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncUserOplogMsg:
 		err = pm.HandleSyncUserOplog(dataBytes, peer)
 
-	case ForceSyncUserOplogMsg:
-		err = pm.HandleForceSyncUserOplog(dataBytes, peer)
-	case ForceSyncUserOplogAckMsg:
-		err = pm.HandleForceSyncUserOplogAck(dataBytes, peer)
+	case ForceSyncUserOplogByMerkleMsg:
+		return pm.HandleForceSyncUserOplogByMerkle(dataBytes, peer)
+	case ForceSyncUserOplogByMerkleAckMsg:
+		return pm.HandleForceSyncUserOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncUserOplogByOplogAckMsg:
+		return pm.HandleForceSyncUserOplogByOplogAck(dataBytes, peer)
 	case InvalidSyncUserOplogMsg:
-		err = pm.HandleSyncUserOplogInvalidAck(dataBytes, peer)
+		err = pm.HandleSyncUserOplogInvalid(dataBytes, peer)
 
 	case SyncUserOplogAckMsg:
 		err = pm.HandleSyncUserOplogAck(dataBytes, peer)

--- a/content/globals.go
+++ b/content/globals.go
@@ -45,12 +45,17 @@ const (
 	AddPendingBoardOplogsMsg
 
 	SyncBoardOplogMsg
-	ForceSyncBoardOplogMsg
-	ForceSyncBoardOplogAckMsg
-	InvalidSyncBoardOplogMsg
 	SyncBoardOplogAckMsg
 	SyncBoardOplogNewOplogsMsg
 	SyncBoardOplogNewOplogsAckMsg
+
+	InvalidSyncBoardOplogMsg
+
+	ForceSyncBoardOplogMsg
+	ForceSyncBoardOplogAckMsg
+	ForceSyncBoardOplogByMerkleMsg
+	ForceSyncBoardOplogByMerkleAckMsg
+	ForceSyncBoardOplogByOplogAckMsg
 
 	SyncPendingBoardOplogMsg
 	SyncPendingBoardOplogAckMsg

--- a/content/protocol_handle_board_oplogs.go
+++ b/content/protocol_handle_board_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncBoardOplog(dataBytes []byte, peer *pkgservi
 
 		pm.boardOplogMerkle,
 
-		ForceSyncBoardOplogMsg,
-		ForceSyncBoardOplogAckMsg,
+		ForceSyncBoardOplogByMerkleMsg,
+		ForceSyncBoardOplogByMerkleAckMsg,
 		InvalidSyncBoardOplogMsg,
 		SyncBoardOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncBoardOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncBoardOplogByMerkleAckMsg,
+		ForceSyncBoardOplogByOplogAckMsg,
+
+		pm.SetBoardDB,
+		pm.SetNewestBoardOplog,
+
+		pm.boardOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncBoardOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncBoardOplogByMerkleMsg,
+
+		pm.boardOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncBoardOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleBoardOplogs,
+
+		pm.boardOplogMerkle,
 	)
 }
 
@@ -86,14 +123,14 @@ func (pm *ProtocolManager) HandleForceSyncBoardOplogAck(dataBytes []byte, peer *
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncBoardOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncBoardOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 
 		pm.boardOplogMerkle,
-		ForceSyncBoardOplogMsg,
+		ForceSyncBoardOplogByMerkleMsg,
 	)
 }
 

--- a/content/protocol_manager_utils_handle_message.go
+++ b/content/protocol_manager_utils_handle_message.go
@@ -29,12 +29,14 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncBoardOplogMsg:
 		err = pm.HandleSyncBoardOplog(dataBytes, peer)
 
-	case ForceSyncBoardOplogMsg:
-		err = pm.HandleForceSyncBoardOplog(dataBytes, peer)
-	case ForceSyncBoardOplogAckMsg:
-		err = pm.HandleForceSyncBoardOplogAck(dataBytes, peer)
+	case ForceSyncBoardOplogByMerkleMsg:
+		return pm.HandleForceSyncBoardOplogByMerkle(dataBytes, peer)
+	case ForceSyncBoardOplogByMerkleAckMsg:
+		return pm.HandleForceSyncBoardOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncBoardOplogByOplogAckMsg:
+		return pm.HandleForceSyncBoardOplogByOplogAck(dataBytes, peer)
 	case InvalidSyncBoardOplogMsg:
-		err = pm.HandleSyncBoardOplogInvalidAck(dataBytes, peer)
+		err = pm.HandleSyncBoardOplogInvalid(dataBytes, peer)
 
 	case SyncBoardOplogAckMsg:
 		err = pm.HandleSyncBoardOplogAck(dataBytes, peer)

--- a/friend/globals.go
+++ b/friend/globals.go
@@ -71,12 +71,17 @@ const (
 	AddPendingFriendOplogsMsg
 
 	SyncFriendOplogMsg
-	ForceSyncFriendOplogMsg
-	ForceSyncFriendOplogAckMsg
-	InvalidSyncFriendOplogMsg
 	SyncFriendOplogAckMsg
 	SyncFriendOplogNewOplogsMsg
 	SyncFriendOplogNewOplogsAckMsg
+
+	InvalidSyncFriendOplogMsg
+
+	ForceSyncFriendOplogMsg
+	ForceSyncFriendOplogAckMsg
+	ForceSyncFriendOplogByMerkleMsg
+	ForceSyncFriendOplogByMerkleAckMsg
+	ForceSyncFriendOplogByOplogAckMsg
 
 	SyncPendingFriendOplogMsg
 	SyncPendingFriendOplogAckMsg

--- a/friend/protocol_handle_friend_oplogs.go
+++ b/friend/protocol_handle_friend_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncFriendOplog(dataBytes []byte, peer *pkgserv
 
 		pm.friendOplogMerkle,
 
-		ForceSyncFriendOplogMsg,
-		ForceSyncFriendOplogAckMsg,
+		ForceSyncFriendOplogByMerkleMsg,
+		ForceSyncFriendOplogByMerkleAckMsg,
 		InvalidSyncFriendOplogMsg,
 		SyncFriendOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncFriendOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncFriendOplogByMerkleAckMsg,
+		ForceSyncFriendOplogByOplogAckMsg,
+
+		pm.SetFriendDB,
+		pm.SetNewestFriendOplog,
+
+		pm.friendOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncFriendOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncFriendOplogByMerkleMsg,
+
+		pm.friendOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncFriendOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleFriendOplogs,
+
+		pm.friendOplogMerkle,
 	)
 }
 
@@ -86,14 +123,14 @@ func (pm *ProtocolManager) HandleForceSyncFriendOplogAck(dataBytes []byte, peer 
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncFriendOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncFriendOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 
 		pm.friendOplogMerkle,
-		ForceSyncFriendOplogMsg,
+		ForceSyncFriendOplogByMerkleMsg,
 	)
 }
 

--- a/friend/protocol_manager_utils_handle_message.go
+++ b/friend/protocol_manager_utils_handle_message.go
@@ -31,12 +31,14 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncFriendOplogMsg:
 		err = pm.HandleSyncFriendOplog(dataBytes, peer)
 
-	case ForceSyncFriendOplogMsg:
-		err = pm.HandleForceSyncFriendOplog(dataBytes, peer)
-	case ForceSyncFriendOplogAckMsg:
-		err = pm.HandleForceSyncFriendOplogAck(dataBytes, peer)
+	case ForceSyncFriendOplogByMerkleMsg:
+		return pm.HandleForceSyncFriendOplogByMerkle(dataBytes, peer)
+	case ForceSyncFriendOplogByMerkleAckMsg:
+		return pm.HandleForceSyncFriendOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncFriendOplogByOplogAckMsg:
+		return pm.HandleForceSyncFriendOplogByOplogAck(dataBytes, peer)
 	case InvalidSyncFriendOplogMsg:
-		err = pm.HandleSyncFriendOplogInvalidAck(dataBytes, peer)
+		err = pm.HandleSyncFriendOplogInvalid(dataBytes, peer)
 
 	case SyncFriendOplogAckMsg:
 		err = pm.HandleSyncFriendOplogAck(dataBytes, peer)

--- a/me/globals.go
+++ b/me/globals.go
@@ -53,12 +53,17 @@ const (
 	AddPendingMeOplogsMsg
 
 	SyncMeOplogMsg // 47
-	ForceSyncMeOplogMsg
-	ForceSyncMeOplogAckMsg
-	InvalidSyncMeOplogMsg
 	SyncMeOplogAckMsg
 	SyncMeOplogNewOplogsMsg
 	SyncMeOplogNewOplogsAckMsg
+
+	InvalidSyncMeOplogMsg
+
+	ForceSyncMeOplogMsg
+	ForceSyncMeOplogAckMsg
+	ForceSyncMeOplogByMerkleMsg
+	ForceSyncMeOplogByMerkleAckMsg
+	ForceSyncMeOplogByOplogAckMsg
 
 	SyncPendingMeOplogMsg
 	SyncPendingMeOplogAckMsg

--- a/me/protocol_handle_me_oplogs.go
+++ b/me/protocol_handle_me_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncMeOplog(dataBytes []byte, peer *pkgservice.
 
 		pm.meOplogMerkle,
 
-		ForceSyncMeOplogMsg,
-		ForceSyncMeOplogAckMsg,
+		ForceSyncMeOplogByMerkleMsg,
+		ForceSyncMeOplogByMerkleAckMsg,
 		InvalidSyncMeOplogMsg,
 		SyncMeOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncMeOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncMeOplogByMerkleAckMsg,
+		ForceSyncMeOplogByOplogAckMsg,
+
+		pm.SetMeDB,
+		pm.SetNewestMeOplog,
+
+		pm.meOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncMeOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncMeOplogByMerkleMsg,
+
+		pm.meOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncMeOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleMeOplogs,
+
+		pm.meOplogMerkle,
 	)
 }
 
@@ -88,12 +125,12 @@ func (pm *ProtocolManager) HandleForceSyncMeOplogAck(dataBytes []byte, peer *pkg
 
 func (pm *ProtocolManager) HandleSyncMeOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 
 		pm.meOplogMerkle,
-		ForceSyncMeOplogMsg,
+		ForceSyncMeOplogByMerkleMsg,
 	)
 }
 

--- a/me/protocol_manager_utils_handle_message.go
+++ b/me/protocol_manager_utils_handle_message.go
@@ -51,10 +51,12 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncMeOplogMsg:
 		err = pm.HandleSyncMeOplog(dataBytes, peer)
 
-	case ForceSyncMeOplogMsg:
-		err = pm.HandleForceSyncMeOplog(dataBytes, peer)
-	case ForceSyncMeOplogAckMsg:
-		err = pm.HandleForceSyncMeOplogAck(dataBytes, peer)
+	case ForceSyncMeOplogByMerkleMsg:
+		return pm.HandleForceSyncMeOplogByMerkle(dataBytes, peer)
+	case ForceSyncMeOplogByMerkleAckMsg:
+		return pm.HandleForceSyncMeOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncMeOplogByOplogAckMsg:
+		return pm.HandleForceSyncMeOplogByOplogAck(dataBytes, peer)
 	case InvalidSyncMeOplogMsg:
 		err = pm.HandleSyncMeOplogInvalidAck(dataBytes, peer)
 

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -212,6 +212,8 @@ func TestNewPeer(t *testing.T) {
 		t.Errorf("Caps mismatch: got %v, expected %v", p.Caps(), caps)
 	}
 
+	close(p.closed)
+
 	p.Disconnect(DiscAlreadyConnected) // Should not hang
 }
 

--- a/service/errors.go
+++ b/service/errors.go
@@ -93,6 +93,8 @@ var (
 	ErrNotAlive = errors.New("not alive")
 
 	ErrInvalidFunc = errors.New("invalid function")
+
+	ErrInvalidMerkle = errors.New("invalid merkle")
 )
 
 func ErrResp(code error, format string, v ...interface{}) error {

--- a/service/globals.go
+++ b/service/globals.go
@@ -158,13 +158,13 @@ const (
 	SyncPendingMemberOplogAckMsg
 
 	// peer
-	IdentifyPeerMsg // 37
-	IdentifyPeerAckMsg
+	IdentifyPeerMsg
+	IdentifyPeerAckMsg // 53
 
 	BoardLastSeenMsg
 	ArticleLastSeenMsg
 
-	NMsg
+	NMsg // 56
 )
 
 // member

--- a/service/globals.go
+++ b/service/globals.go
@@ -98,10 +98,13 @@ const (
 	AddPendingOpKeyOplogsMsg
 
 	SyncOpKeyOplogMsg
+	SyncOpKeyOplogAckMsg
+
+	InvalidSyncOpKeyOplogMsg
+
 	ForceSyncOpKeyOplogMsg
 	ForceSyncOpKeyOplogAckMsg
-	InvalidSyncOpKeyOplogMsg
-	SyncOpKeyOplogAckMsg
+
 	SyncPendingOpKeyOplogMsg
 	SyncPendingOpKeyOplogAckMsg
 
@@ -116,12 +119,17 @@ const (
 	AddPendingMasterOplogsMsg
 
 	SyncMasterOplogMsg
-	ForceSyncMasterOplogMsg
-	ForceSyncMasterOplogAckMsg
-	InvalidSyncMasterOplogMsg
 	SyncMasterOplogAckMsg
 	SyncMasterOplogNewOplogsMsg
 	SyncMasterOplogNewOplogsAckMsg
+
+	InvalidSyncMasterOplogMsg
+
+	ForceSyncMasterOplogMsg
+	ForceSyncMasterOplogAckMsg
+	ForceSyncMasterOplogByMerkleMsg
+	ForceSyncMasterOplogByMerkleAckMsg
+	ForceSyncMasterOplogByOplogAckMsg
 
 	SyncPendingMasterOplogMsg
 	SyncPendingMasterOplogAckMsg
@@ -134,12 +142,17 @@ const (
 	AddPendingMemberOplogsMsg
 
 	SyncMemberOplogMsg
-	ForceSyncMemberOplogMsg
-	ForceSyncMemberOplogAckMsg
-	InvalidSyncMemberOplogMsg
 	SyncMemberOplogAckMsg
 	SyncMemberOplogNewOplogsMsg
 	SyncMemberOplogNewOplogsAckMsg
+
+	InvalidSyncMemberOplogMsg
+
+	ForceSyncMemberOplogMsg
+	ForceSyncMemberOplogAckMsg
+	ForceSyncMemberOplogByMerkleMsg
+	ForceSyncMemberOplogByMerkleAckMsg
+	ForceSyncMemberOplogByOplogAckMsg
 
 	SyncPendingMemberOplogMsg
 	SyncPendingMemberOplogAckMsg
@@ -272,6 +285,9 @@ var (
 	NMerkleTreeMagicAlloc   = 50
 	MerkleTreeOffsetAddr    = SizeMerkleTreeLevel
 	MerkleTreeOffsetTS      = MerkleTreeOffsetAddr + common.AddressLength
+
+	MerkleTreeKeyOffsetLevel    = pttdb.SizeDBKeyPrefix + types.SizePttID
+	MerkleTreeKeyOffsetUpdateTS = MerkleTreeKeyOffsetLevel + SizeMerkleTreeLevel
 
 	DBMerkleGenerateTimePrefix = []byte(".mtgt")
 	DBMerkleSyncTimePrefix     = []byte(".mtst")

--- a/service/merkle.go
+++ b/service/merkle.go
@@ -1020,12 +1020,12 @@ func DiffMerkleTree(
 	}
 
 	if len(pMyNodes) > 0 {
-		log.Error("DiffMerkleTree: myNodes", "ts", pMyNodes[0].UpdateTS, "level", pMyNodes[0].Level)
+		log.Error("DiffMerkleTree: myNodes", "ts", pMyNodes[0].UpdateTS, "level", pMyNodes[0].Level, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 		theirNewNodes = append(theirNewNodes, pMyNodes...)
 	}
 
 	if len(pTheirNodes) > 0 {
-		log.Error("DiffMerkleTree: theirNodes", "ts", pTheirNodes[0].UpdateTS, "level", pTheirNodes[0].Level)
+		log.Error("DiffMerkleTree: theirNodes", "ts", pTheirNodes[0].UpdateTS, "level", pTheirNodes[0].Level, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 		myNewNodes = append(myNewNodes, pTheirNodes...)
 	}
 

--- a/service/oplog.go
+++ b/service/oplog.go
@@ -507,6 +507,7 @@ func (o *BaseOplog) DBPrefixMaster() []byte {
 MarshalKey: prefixID:TS:OplogID:Op
 */
 func (o *BaseOplog) MarshalMerkleKey() ([]byte, error) {
+	// XXX the ts in Key in MerkleTreeLevelNow is the same as UpdateTS
 	marshaledTS, err := o.UpdateTS.Marshal()
 	if err != nil {
 		return nil, err

--- a/service/protocol_approve_join_entity.go
+++ b/service/protocol_approve_join_entity.go
@@ -114,7 +114,8 @@ func (pm *BaseProtocolManager) ApproveJoin(
 
 	switch {
 	case peer.PeerType < PeerTypeMember:
-		pm.Ptt().SetupPeer(peer, PeerTypeMember, false)
+		pm.Ptt().ResetPeerType(peer, false, false)
+		pm.RegisterPeer(peer, PeerTypeMember, false)
 	case peer.PeerType == PeerTypeMe:
 		pm.RegisterPeer(peer, PeerTypeMe, false)
 	default:

--- a/service/protocol_force_sync_oplog_ack.go
+++ b/service/protocol_force_sync_oplog_ack.go
@@ -121,7 +121,7 @@ func (pm *BaseProtocolManager) HandleForceSyncOplogAck(
 
 	myNodes = pm.handleSyncOplogAckFilterTS(myNodes, data.StartTS, data.EndTS)
 
-	myNewKeys, theirNewKeys, err := MergeMerkleNodeKeys(myNodes, data.Nodes)
+	myNewKeys, theirNewKeys, err := MergeMerkleKeys(myNodes, data.Nodes)
 	if err != nil {
 		return err
 	}

--- a/service/protocol_force_sync_oplog_by_merkle.go
+++ b/service/protocol_force_sync_oplog_by_merkle.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+type ForceSyncOplogByMerkle struct {
+	UpdateTS types.Timestamp `json:"UT"`
+	Level    MerkleTreeLevel `json:"L"`
+	Keys     [][]byte        `json:"K"`
+}
+
+func (pm *BaseProtocolManager) ForceSyncOplogByMerkle(
+	myNewNode *MerkleNode,
+
+	forceSyncOplogMsg OpType,
+
+	merkle *Merkle,
+
+	peer *PttPeer,
+) error {
+
+	myNode, _ := merkle.GetNodeByLevelTS(myNewNode.Level, myNewNode.UpdateTS)
+
+	log.Debug("ForceSyncOplogByMerkle: to GetChildKeys", "myNode", myNode, "myNewNode", myNewNode, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
+	keys, err := merkle.GetChildKeys(myNewNode.Level, myNewNode.UpdateTS)
+	log.Debug("ForceSyncOplogByMerkle: after GetChildKeys", "e", err, "level", myNewNode.Level, "TS", myNewNode.UpdateTS, "keys", keys, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	if err != nil {
+		return err
+	}
+
+	if myNode != nil && len(keys) != int(myNode.NChildren) {
+		log.Debug("ForceSyncOplogByMerkle: len != NChildren", "len", len(keys), "children", myNode.NChildren, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+		return merkle.TryForceSync(pm)
+	}
+
+	if myNode == nil && len(keys) != 0 {
+		log.Debug("ForceSyncOplogByMerkle: len != 0", "len", len(keys), "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+		return merkle.TryForceSync(pm)
+	}
+
+	data := &ForceSyncOplogByMerkle{
+		UpdateTS: myNewNode.UpdateTS,
+		Level:    myNewNode.Level,
+		Keys:     keys,
+	}
+
+	err = pm.SendDataToPeer(forceSyncOplogMsg, data, peer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncOplogByMerkle(
+	dataBytes []byte,
+	peer *PttPeer,
+
+	forceSyncOplogAckMsg OpType,
+	forceSyncOplogByOplogAckMsg OpType,
+
+	setDB func(oplog *BaseOplog),
+
+	setNewestOplog func(log *BaseOplog) error,
+
+	merkle *Merkle,
+) error {
+	ptt := pm.Ptt()
+	myInfo := ptt.GetMyEntity()
+	if myInfo.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	e := pm.Entity()
+	if e.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	data := &ForceSyncOplogByMerkle{}
+	err := json.Unmarshal(dataBytes, data)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("HandleForceSyncOplogByMerkle: to GetChildKeys", "level", data.Level, "TS", data.UpdateTS, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
+	keys, err := merkle.GetChildKeys(data.Level, data.UpdateTS)
+	log.Debug("HandleForceSyncOplogByMerkle: after GetChildKeys", "level", data.Level, "TS", data.UpdateTS, "keys", keys, "e", err, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	if err != nil {
+		return err
+	}
+
+	myNewKeys, theirNewKeys, err := DiffMerkleKeys(keys, data.Keys)
+	log.Debug("HandleForceSyncOplogByMerkle: after DiffMerkleKeys", "myNewKeys", myNewKeys, "theirNewKeys", theirNewKeys, "e", err, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	if err != nil {
+		return err
+	}
+
+	if data.Level == MerkleTreeLevelHR {
+		return pm.ForceSyncOplogByOplogAck(
+			theirNewKeys,
+			forceSyncOplogByOplogAckMsg,
+			setDB,
+			setNewestOplog,
+			peer,
+			merkle,
+		)
+	}
+
+	return pm.ForceSyncOplogByMerkleAck(
+		theirNewKeys,
+		forceSyncOplogAckMsg,
+		merkle,
+		peer,
+	)
+}

--- a/service/protocol_force_sync_oplog_by_merkle_ack.go
+++ b/service/protocol_force_sync_oplog_by_merkle_ack.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+type ForceSyncOplogByMerkleAck struct {
+	Keys [][]byte `json:"K"`
+}
+
+func (pm *BaseProtocolManager) ForceSyncOplogByMerkleAck(
+	keys [][]byte,
+
+	forceSyncOplogAckMsg OpType,
+	merkle *Merkle,
+
+	peer *PttPeer,
+
+) error {
+
+	data := &ForceSyncOplogByMerkleAck{
+		Keys: keys,
+	}
+
+	err := pm.SendDataToPeer(forceSyncOplogAckMsg, data, peer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncOplogByMerkleAck(
+	dataBytes []byte,
+	peer *PttPeer,
+
+	forceSyncOplogMsg OpType,
+
+	merkle *Merkle,
+) error {
+
+	ptt := pm.Ptt()
+	myInfo := ptt.GetMyEntity()
+	if myInfo.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	e := pm.Entity()
+	if e.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	data := &ForceSyncOplogByMerkleAck{}
+	err := json.Unmarshal(dataBytes, data)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("HandleForceSyncOplogByMerkleAck: to for-loop", "keys", data.Keys, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
+	node := &MerkleNode{}
+	for _, key := range data.Keys {
+		node.ConstructUpdateTSAndLevelByKey(key)
+		log.Debug("HandleForceSyncOplogByMerkleAck: (in-for-loop)", "node", node, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+		pm.ForceSyncOplogByMerkle(node, forceSyncOplogMsg, merkle, peer)
+	}
+
+	return nil
+}

--- a/service/protocol_force_sync_oplog_by_oplog_ack.go
+++ b/service/protocol_force_sync_oplog_by_oplog_ack.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+type ForceSyncOplogByOplogAck struct {
+	Oplogs []*BaseOplog `json:"O"`
+}
+
+func (pm *BaseProtocolManager) ForceSyncOplogByOplogAck(
+	theirNewKeys [][]byte,
+
+	forceSyncOplogByOplogAckMsg OpType,
+
+	setDB func(oplog *BaseOplog),
+	setNewestOplog func(log *BaseOplog) error,
+
+	peer *PttPeer,
+
+	merkle *Merkle,
+) error {
+
+	theirNewLogs, err := getOplogsFromKeys(setDB, theirNewKeys)
+	log.Debug("ForceSyncOplogByOplogAck: after get theirNewLogs", "theirNewLogs", len(theirNewLogs), "e", err, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	if err != nil {
+		return err
+	}
+
+	if len(theirNewLogs) == 0 {
+		return nil
+	}
+
+	if setNewestOplog != nil {
+		for _, log := range theirNewLogs {
+			setNewestOplog(log)
+		}
+	}
+
+	data := &SyncOplogNewOplogs{
+		Oplogs: theirNewLogs,
+	}
+
+	err = pm.SendDataToPeer(forceSyncOplogByOplogAckMsg, data, peer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncOplogByOplogAck(
+	dataBytes []byte,
+	peer *PttPeer,
+
+	handleOplogs func(oplogs []*BaseOplog, peer *PttPeer, isUpdateSyncTime bool) error,
+
+	merkle *Merkle,
+
+) error {
+
+	ptt := pm.Ptt()
+	myInfo := ptt.GetMyEntity()
+	if myInfo.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	entity := pm.Entity()
+	if entity.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	data := &ForceSyncOplogByOplogAck{}
+	err := json.Unmarshal(dataBytes, data)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("HandleForceSyncOplogByOplogAck: to handleOplogs", "oplogs", data.Oplogs, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
+	err = handleOplogs(data.Oplogs, peer, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/service/protocol_handle_master_oplogs.go
+++ b/service/protocol_handle_master_oplogs.go
@@ -52,10 +52,47 @@ func (pm *BaseProtocolManager) HandleSyncMasterOplog(dataBytes []byte, peer *Ptt
 
 		pm.MasterMerkle(),
 
-		ForceSyncMasterOplogMsg,
-		ForceSyncMasterOplogAckMsg,
+		ForceSyncMasterOplogByMerkleMsg,
+		ForceSyncMasterOplogByMerkleAckMsg,
 		InvalidSyncMasterOplogMsg,
 		SyncMasterOplogAckMsg,
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMasterOplogByMerkle(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncMasterOplogByMerkleAckMsg,
+		ForceSyncMasterOplogByOplogAckMsg,
+
+		pm.SetMasterDB,
+		pm.SetNewestMasterOplog,
+
+		pm.MasterMerkle(),
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMasterOplogByMerkleAck(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncMasterOplogByMerkleMsg,
+
+		pm.MasterMerkle(),
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMasterOplogByOplogAck(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleMasterOplogs,
+
+		pm.MasterMerkle(),
 	)
 }
 
@@ -89,14 +126,14 @@ func (pm *BaseProtocolManager) HandleForceSyncMasterOplogAck(dataBytes []byte, p
 	)
 }
 
-func (pm *BaseProtocolManager) HandleSyncMasterOplogInvalidAck(dataBytes []byte, peer *PttPeer) error {
+func (pm *BaseProtocolManager) HandleSyncMasterOplogInvalid(dataBytes []byte, peer *PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 
 		pm.MasterMerkle(),
-		ForceSyncMasterOplogMsg,
+		ForceSyncMasterOplogByMerkleMsg,
 	)
 }
 

--- a/service/protocol_handle_member_oplogs.go
+++ b/service/protocol_handle_member_oplogs.go
@@ -47,10 +47,47 @@ func (pm *BaseProtocolManager) HandleSyncMemberOplog(dataBytes []byte, peer *Ptt
 
 		pm.MemberMerkle(),
 
-		ForceSyncMemberOplogMsg,
-		ForceSyncMemberOplogAckMsg,
+		ForceSyncMemberOplogByMerkleMsg,
+		ForceSyncMemberOplogByMerkleAckMsg,
 		InvalidSyncMemberOplogMsg,
 		SyncMemberOplogAckMsg,
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMemberOplogByMerkle(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncMemberOplogByMerkleAckMsg,
+		ForceSyncMemberOplogByOplogAckMsg,
+
+		pm.SetMemberDB,
+		pm.SetNewestMemberOplog,
+
+		pm.MemberMerkle(),
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMemberOplogByMerkleAck(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncMemberOplogByMerkleMsg,
+
+		pm.MemberMerkle(),
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMemberOplogByOplogAck(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleMemberOplogs,
+
+		pm.MemberMerkle(),
 	)
 }
 
@@ -84,14 +121,14 @@ func (pm *BaseProtocolManager) HandleForceSyncMemberOplogAck(dataBytes []byte, p
 	)
 }
 
-func (pm *BaseProtocolManager) HandleSyncMemberOplogInvalidAck(dataBytes []byte, peer *PttPeer) error {
+func (pm *BaseProtocolManager) HandleSyncMemberOplogInvalid(dataBytes []byte, peer *PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 
 		pm.MemberMerkle(),
-		ForceSyncMemberOplogMsg,
+		ForceSyncMemberOplogByMerkleMsg,
 	)
 }
 

--- a/service/protocol_identify_peer_ack.go
+++ b/service/protocol_identify_peer_ack.go
@@ -73,7 +73,7 @@ func (pm *BaseProtocolManager) HandleIdentifyPeerAck(dataBytes []byte, peer *Ptt
 		return err
 	}
 
-	log.Debug("HandleIdentifyPeerAck: to ptt.HandleIdentifyPeerAck")
+	log.Info("HandleIdentifyPeerAck: to ptt.HandleIdentifyPeerAck", "peer", peer)
 
 	ptt := pm.Ptt()
 
@@ -142,7 +142,7 @@ func (p *BasePtt) HandleIdentifyPeerAck(entityID *types.PttID, data *IdentifyPee
 
 	peer.FinishID(entityID)
 
-	log.Debug("HandleIdentifyPeerAck: to FinishIdentifyPeer", "peer", peer, "userID", peer.UserID)
+	log.Info("HandleIdentifyPeerAck: to FinishIdentifyPeer", "peer", peer, "userID", peer.UserID)
 
 	return p.FinishIdentifyPeer(peer, false, false)
 }

--- a/service/protocol_manager.go
+++ b/service/protocol_manager.go
@@ -124,7 +124,10 @@ type ProtocolManager interface {
 
 	HandleForceSyncMasterOplog(dataBytes []byte, peer *PttPeer) error
 	HandleForceSyncMasterOplogAck(dataBytes []byte, peer *PttPeer) error
-	HandleSyncMasterOplogInvalidAck(dataBytes []byte, peer *PttPeer) error
+	HandleForceSyncMasterOplogByMerkle(dataBytes []byte, peer *PttPeer) error
+	HandleForceSyncMasterOplogByMerkleAck(dataBytes []byte, peer *PttPeer) error
+	HandleForceSyncMasterOplogByOplogAck(dataBytes []byte, peer *PttPeer) error
+	HandleSyncMasterOplogInvalid(dataBytes []byte, peer *PttPeer) error
 
 	HandleSyncMasterOplogAck(dataBytes []byte, peer *PttPeer) error
 	HandleSyncNewMasterOplog(dataBytes []byte, peer *PttPeer) error
@@ -154,7 +157,10 @@ type ProtocolManager interface {
 
 	HandleForceSyncMemberOplog(dataBytes []byte, peer *PttPeer) error
 	HandleForceSyncMemberOplogAck(dataBytes []byte, peer *PttPeer) error
-	HandleSyncMemberOplogInvalidAck(dataBytes []byte, peer *PttPeer) error
+	HandleForceSyncMemberOplogByMerkle(dataBytes []byte, peer *PttPeer) error
+	HandleForceSyncMemberOplogByMerkleAck(dataBytes []byte, peer *PttPeer) error
+	HandleForceSyncMemberOplogByOplogAck(dataBytes []byte, peer *PttPeer) error
+	HandleSyncMemberOplogInvalid(dataBytes []byte, peer *PttPeer) error
 
 	HandleSyncMemberOplogAck(dataBytes []byte, peer *PttPeer) error
 	HandleSyncNewMemberOplog(dataBytes []byte, peer *PttPeer) error

--- a/service/protocol_manager_utils_handle_message.go
+++ b/service/protocol_manager_utils_handle_message.go
@@ -44,12 +44,14 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 	case SyncMasterOplogMsg:
 		return pm.HandleSyncMasterOplog(dataBytes, peer)
 
-	case ForceSyncMasterOplogMsg:
-		return pm.HandleForceSyncMasterOplog(dataBytes, peer)
-	case ForceSyncMasterOplogAckMsg:
-		return pm.HandleForceSyncMasterOplogAck(dataBytes, peer)
+	case ForceSyncMasterOplogByMerkleMsg:
+		return pm.HandleForceSyncMasterOplogByMerkle(dataBytes, peer)
+	case ForceSyncMasterOplogByMerkleAckMsg:
+		return pm.HandleForceSyncMasterOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncMasterOplogByOplogAckMsg:
+		return pm.HandleForceSyncMasterOplogByOplogAck(dataBytes, peer)
 	case InvalidSyncMasterOplogMsg:
-		return pm.HandleSyncMasterOplogInvalidAck(dataBytes, peer)
+		return pm.HandleSyncMasterOplogInvalid(dataBytes, peer)
 
 	case SyncMasterOplogAckMsg:
 		return pm.HandleSyncMasterOplogAck(dataBytes, peer)
@@ -75,12 +77,14 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 	case SyncMemberOplogMsg:
 		return pm.HandleSyncMemberOplog(dataBytes, peer)
 
-	case ForceSyncMemberOplogMsg:
-		return pm.HandleForceSyncMemberOplog(dataBytes, peer)
-	case ForceSyncMemberOplogAckMsg:
-		return pm.HandleForceSyncMemberOplogAck(dataBytes, peer)
+	case ForceSyncMemberOplogByMerkleMsg:
+		return pm.HandleForceSyncMemberOplogByMerkle(dataBytes, peer)
+	case ForceSyncMemberOplogByMerkleAckMsg:
+		return pm.HandleForceSyncMemberOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncMemberOplogByOplogAckMsg:
+		return pm.HandleForceSyncMemberOplogByOplogAck(dataBytes, peer)
 	case InvalidSyncMemberOplogMsg:
-		return pm.HandleSyncMemberOplogInvalidAck(dataBytes, peer)
+		return pm.HandleSyncMemberOplogInvalid(dataBytes, peer)
 
 	case SyncMemberOplogAckMsg:
 		return pm.HandleSyncMemberOplogAck(dataBytes, peer)

--- a/service/protocol_manager_utils_handle_message.go
+++ b/service/protocol_manager_utils_handle_message.go
@@ -29,7 +29,7 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 	}
 
 	op, dataBytes, err := pm.Ptt().DecryptData(encData, opKeyInfo)
-	log.Debug("PMHandleMessageWrapper: after DecryptData", "e", err, "op", op, "NMsg", NMsg)
+	// log.Info("PMHandleMessageWrapper: after DecryptData", "e", err, "op", op, "NMsg", NMsg, "peer", peer)
 	if err != nil {
 		return err
 	}
@@ -134,9 +134,9 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 
 	}
 
-	log.Debug("PMHandleMessageWrapper: to GetPeerType", "peer", peer, "entity", pm.Entity().GetID())
+	//log.Debug("PMHandleMessageWrapper: to GetPeerType", "peer", peer, "entity", pm.Entity().GetID())
 	fitPeerType := pm.GetPeerType(peer)
-	log.Debug("PMHandleMessageWrapper: after GetPeerType", "peer", peer, "entity", pm.Entity().GetID(), "fitPeerType", fitPeerType)
+	// log.Info("PMHandleMessageWrapper: after GetPeerType", "peer", peer, "entity", pm.Entity().GetID(), "fitPeerType", fitPeerType)
 
 	var origPeer *PttPeer
 	if fitPeerType < PeerTypePending {
@@ -150,8 +150,18 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 	origPeer = pm.Peers().GetPeerWithPeerType(peer.GetID(), fitPeerType, false)
 
 	if origPeer == nil {
+		log.Info("PMHandleMessageWrapper: to RegisterPeer", "peer", peer, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name(), "fitPeerType", fitPeerType)
+
 		pm.RegisterPeer(peer, fitPeerType, false)
+		log.Info("PMHandleMessageWrapper: after RegisterPeer", "peer", peer, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 	}
 
-	return pm.HandleMessage(op, dataBytes, peer)
+	err = pm.HandleMessage(op, dataBytes, peer)
+	// log.Info("PMHandleMessageWrapper: after HandleMessage", "e", err, "peer", peer, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/service/protocol_manager_utils_merkle.go
+++ b/service/protocol_manager_utils_merkle.go
@@ -32,7 +32,7 @@ func PMOplogMerkleTreeLoop(pm ProtocolManager, merkle *Merkle) error {
 
 	merkle.LoadToUpdateTSs()
 	tsList, err := merkle.LoadUpdatingTSList()
-	log.Debug("PMOplogMerkleTreeLoop: after LoadUpdatingTSList", "tsList", tsList, "e", err, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	log.Debug("PMOplogMerkleTreeLoop: after LoadUpdatingTSList", "tsList", tsList, "e", err, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 	if err == nil {
 		for _, sec := range tsList {
 			ts.Ts = sec
@@ -46,9 +46,15 @@ loop:
 	for {
 		select {
 		case <-ticker.C:
+			log.Debug("PMOplogMerkleTreeLoop (ticker): to pmGenerateOplogMerkleTree", "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 			pmGenerateOplogMerkleTree(pm, merkle)
+			log.Debug("PMOplogMerkleTreeLoop (ticker): after pmGenerateOplogMerkleTree", "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+		case <-merkle.ForceSync():
+			log.Debug("PMOplogMerkleTreeLoop (forceSync): to pmGenerateOplogMerkleTree", "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+			pmGenerateOplogMerkleTree(pm, merkle)
+			log.Debug("PMOplogMerkleTreeLoop (forceSync): after pmGenerateOplogMerkleTree", "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 		case <-pm.QuitSync():
-			log.Debug("PMOplogMerkleTreeLoop: QuitSync", "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+			log.Debug("PMOplogMerkleTreeLoop: QuitSync", "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
 			break loop
 		}
 	}

--- a/service/protocol_manager_utils_sync.go
+++ b/service/protocol_manager_utils_sync.go
@@ -104,7 +104,14 @@ func pmSyncPeer(pm ProtocolManager) (*PttPeer, error) {
 		pm.LoadPeers()
 		return nil, nil
 	}
-	peer := RandomPeer(peerList)
+
+	validPeerList := make([]*PttPeer, 0, len(peerList))
+	for _, peer := range peerList {
+		if peer.IsReady {
+			validPeerList = append(validPeerList, peer)
+		}
+	}
+	peer := RandomPeer(validPeerList)
 
 	return peer, nil
 }

--- a/service/protocol_sync_oplog_ack.go
+++ b/service/protocol_sync_oplog_ack.go
@@ -59,11 +59,13 @@ func (pm *BaseProtocolManager) SyncOplogAck(
 
 	offsetHourTS, _ := myToSyncTime.ToHRTimestamp()
 
-	err := pm.ForceSyncOplogAck(toSyncTime, offsetHourTS, merkle, forceSyncOplogAckMsg, peer)
-	log.Debug("SyncOplogAck: after ForceSyncOplogAck", "toSyncTime", toSyncTime, "offsetHourTS", offsetHourTS, "e", err, "entity", pm.Entity().GetID())
-	if err != nil {
-		return err
-	}
+	/*
+		err := pm.ForceSyncOplogAck(toSyncTime, offsetHourTS, merkle, forceSyncOplogAckMsg, peer)
+		log.Debug("SyncOplogAck: after ForceSyncOplogAck", "toSyncTime", toSyncTime, "offsetHourTS", offsetHourTS, "e", err, "entity", pm.Entity().GetID())
+		if err != nil {
+			return err
+		}
+	*/
 
 	now, err := types.GetTimestamp()
 	if err != nil {
@@ -260,8 +262,8 @@ func (pm *BaseProtocolManager) HandleSyncOplogAck(
 
 	myNodes = pm.handleSyncOplogAckFilterTS(myNodes, data.StartTS, data.EndTS)
 
-	myNewKeys, theirNewKeys, err := MergeMerkleNodeKeys(myNodes, data.Nodes)
-	log.Debug("HandleSyncOplogAck: after MergeMerkleNodeKeys", "myNewKeys", myNewKeys, "theirNewKeys", theirNewKeys, "myNodes", myNodes, "startTS", data.StartTS, "endTS", data.EndTS, "e", err, "entity", pm.Entity().GetID())
+	myNewKeys, theirNewKeys, err := MergeMerkleKeys(myNodes, data.Nodes)
+	log.Debug("HandleSyncOplogAck: after MergeMerkleNodeKeys", "myNewKeys", myNewKeys, "theirNewKeys", theirNewKeys, "myNodes", myNodes, "startTS", data.StartTS, "endTS", data.EndTS, "e", err, "merkle", merkle.Name, "entity", pm.Entity().GetID())
 	if err != nil {
 		return err
 	}

--- a/service/protocol_sync_oplog_invalid.go
+++ b/service/protocol_sync_oplog_invalid.go
@@ -37,7 +37,7 @@ SyncOplogAckInvalid: I (The receiver) Issuing that the sync-oplog is invalid (Va
 	2. if isToSyncPeer: ResyncOplog (with resyncOp. I become the requester.)
 	3. Send invalidOp to the peer (notify it that the oplog is invalid. the peer needs to do some action and resync the oplog.)
 */
-func (pm *BaseProtocolManager) SyncOplogInvalidAck(
+func (pm *BaseProtocolManager) SyncOplogInvalid(
 	peer *PttPeer,
 
 	theirSyncTS types.Timestamp,
@@ -54,7 +54,7 @@ func (pm *BaseProtocolManager) SyncOplogInvalidAck(
 
 	// my devices
 
-	isToSyncPeer := pm.syncOplogInvalidAckIsToSyncPeer(peer, theirSyncTS, mySyncTS)
+	isToSyncPeer := pm.syncOplogInvalidIsToSyncPeer(peer, theirSyncTS, mySyncTS)
 
 	if isToSyncPeer {
 		return pm.ForceSyncOplog(fromSyncTS, toSyncTS, merkle, forceSyncOplogMsg, peer)
@@ -85,7 +85,7 @@ syncOplogAckInvalidIsToSyncPeer checks whether I should sync with the peer.
 	4. => cmp sync-ts.
 	5. => cmp id.
 */
-func (pm *BaseProtocolManager) syncOplogInvalidAckIsToSyncPeer(
+func (pm *BaseProtocolManager) syncOplogInvalidIsToSyncPeer(
 	peer *PttPeer,
 	theirSyncTS types.Timestamp,
 	mySyncTS types.Timestamp,
@@ -141,7 +141,7 @@ HandleSyncOplogAckInvalid: I (the requester) received the msg that my oplogs are
     3.1. if I am connecting to the master => get the master-peer and resync with the master.
     4. Try to connect to the master.
 */
-func (pm *BaseProtocolManager) HandleSyncOplogInvalidAck(
+func (pm *BaseProtocolManager) HandleSyncOplogInvalid(
 	dataBytes []byte,
 	peer *PttPeer,
 	merkle *Merkle,

--- a/service/protocol_sync_oplog_invalid_by_merkle.go
+++ b/service/protocol_sync_oplog_invalid_by_merkle.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import "github.com/ailabstw/go-pttai/log"
+
+func (pm *BaseProtocolManager) SyncOplogInvalidByMerkle(
+	myNewNodes []*MerkleNode,
+	theirNewNodes []*MerkleNode,
+
+	forceSyncOplogMsg OpType,
+	forceSyncOplogAckMsg OpType,
+
+	merkle *Merkle,
+
+	peer *PttPeer,
+
+) error {
+
+	var err error
+	log.Debug("SyncOplogInvalidByMerkle: to ForceSyncOplogByMerkle", "myNewNodes", myNewNodes, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+	for _, node := range myNewNodes {
+		err = pm.ForceSyncOplogByMerkle(
+			node,
+
+			forceSyncOplogMsg,
+
+			merkle,
+			peer,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	theirNewKeys := make([][]byte, 0, len(theirNewNodes))
+	var theirNewKey []byte
+	for _, node := range theirNewNodes {
+		theirNewKey = node.ToKey(merkle)
+		theirNewKeys = append(theirNewKeys, theirNewKey)
+	}
+
+	log.Debug("SyncOplogInvalidByMerkle: to ForceSyncOplogByMerkleAck", "theirNewkeys", theirNewKeys, "merkle", merkle.Name, "entity", pm.Entity().GetID(), "service", pm.Entity().Service().Name())
+
+	err = pm.ForceSyncOplogByMerkleAck(
+		theirNewKeys,
+
+		forceSyncOplogAckMsg,
+
+		merkle,
+		peer,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/service/ptt_peer.go
+++ b/service/ptt_peer.go
@@ -48,6 +48,7 @@ type PttPeer struct {
 	IDChallenge *types.Salt
 	IDChan      chan struct{}
 
+	IsReady   bool
 	IsToClose bool
 }
 

--- a/service/ptt_utils_handle_message.go
+++ b/service/ptt_utils_handle_message.go
@@ -46,7 +46,9 @@ func (p *BasePtt) HandleMessageWrapper(peer *PttPeer) error {
 		return err
 	}
 
+	// log.Info("HandleMessageWrapper: to HandleMessage", "code", msg.Code, "peer", peer)
 	err = p.HandleMessage(CodeType(msg.Code), data, peer)
+	// log.Info("HandleMessageWrapper: after HandleMessage", "e", err, "peer", peer)
 	if err != nil {
 		log.Error("HandleMessageWrapper: unable to handle-msg", "code", msg.Code, "e", err, "peer", peer)
 		return err


### PR DESCRIPTION
intends to fix #190 

1. m.MarshalToUpdateTSKey(hrTS) in merkle.SetUpdateTS
2. merkle.TryForceSync.
3. Rename SyncOplogInvalidAck as SyncOplogInvalid
4. DiffMerkleTree instead of ValidateMerkleTree
5. SyncOplogInvalidByMerkle.
6. ForceSyncOplogByMerkle, ForceSyncOplogByMerkleAck and ForceSyncOplogByOplogAck
7. Remove ForceSyncOplogAck in SyncOplogAck.
8. MergeMerkleNodeKeys => MergeMerkleKeys