### PR TITLE
Do not block in p2p when p.closed.

### DIFF
--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -212,6 +212,8 @@ func TestNewPeer(t *testing.T) {
 		t.Errorf("Caps mismatch: got %v, expected %v", p.Caps(), caps)
 	}
 
+	close(p.closed)
+
 	p.Disconnect(DiscAlreadyConnected) // Should not hang
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -927,9 +927,7 @@ running:
 			err := srv.protoHandshakeChecks(peers, inboundCount, c)
 			if err == nil {
 				// The handshakes are done and it passed all checks.
-				log.Debug("run: to newPeer")
 				p := newPeer(c, srv.Protocols)
-				log.Debug("run: after newPeer")
 				// If message events are enabled, pass the peerFeed
 				// to the peer
 				if srv.EnableMsgEvents {
@@ -937,9 +935,7 @@ running:
 				}
 				name := truncateName(c.name)
 				srv.log.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-				log.Debug("run: to runPeer")
 				go srv.runPeer(p)
-				log.Debug("run: after runPeer")
 				peers[c.id] = p
 				if p.Inbound() {
 					inboundCount++
@@ -1201,9 +1197,9 @@ func (srv *Server) runPeer(p *Peer) {
 	})
 
 	// run the protocol
-	log.Debug("runPeer: to p.run")
+	log.Debug("runPeer: to p.run", "peer", p)
 	remoteRequested, err := p.run()
-	log.Debug("runPeer: after p.run")
+	log.Debug("runPeer: after p.run", "peer", p)
 
 	// broadcast peer drop
 	srv.peerFeed.Send(&PeerEvent{

--- a/service/protocol_approve_join_entity.go
+++ b/service/protocol_approve_join_entity.go
@@ -114,7 +114,8 @@ func (pm *BaseProtocolManager) ApproveJoin(
 
 	switch {
 	case peer.PeerType < PeerTypeMember:
-		pm.Ptt().SetupPeer(peer, PeerTypeMember, false)
+		pm.Ptt().ResetPeerType(peer, false, false)
+		pm.RegisterPeer(peer, PeerTypeMember, false)
 	case peer.PeerType == PeerTypeMe:
 		pm.RegisterPeer(peer, PeerTypeMe, false)
 	default:

--- a/service/ptt.go
+++ b/service/ptt.go
@@ -43,7 +43,6 @@ type Ptt interface {
 	HandleIdentifyPeerAck(entityID *types.PttID, data *IdentifyPeerAck, peer *PttPeer) error
 
 	FinishIdentifyPeer(peer *PttPeer, isLocked bool, isResetPeerType bool) error
-	SetupPeer(peer *PttPeer, peerType PeerType, isLocked bool) error
 
 	ResetPeerType(peer *PttPeer, isLocked bool, isResetPeerType bool) error
 
@@ -107,6 +106,8 @@ type MyPtt interface {
 	MyNodeKey() *ecdsa.PrivateKey
 
 	// SetPeerType
+
+	SetupPeer(peer *PttPeer, peerType PeerType, isLocked bool) error
 
 	SetPeerType(peer *PttPeer, peerType PeerType, isForce bool, isLocked bool) error
 

--- a/service/ptt_utils_peer.go
+++ b/service/ptt_utils_peer.go
@@ -150,13 +150,6 @@ func (p *BasePtt) ResetPeerType(peer *PttPeer, isLocked bool, isForceReset bool)
 		return ErrToClose
 	}
 
-	/*
-		if !isLocked {
-			p.peerLock.Lock()
-			defer p.peerLock.Unlock()
-		}
-	*/
-
 	log.Debug("ResetPeerType", "peer", peer, "userID", peer.UserID)
 
 	if peer.UserID == nil {
@@ -172,7 +165,7 @@ func (p *BasePtt) ResetPeerType(peer *PttPeer, isLocked bool, isForceReset bool)
 		return err
 	}
 
-	err = p.addPeerKnownUserID(peer, peerType, true)
+	err = p.addPeerKnownUserID(peer, peerType, isLocked)
 	if err != nil {
 		return err
 	}
@@ -769,7 +762,7 @@ func (p *BasePtt) AddDial(nodeID *discover.NodeID, opKey *common.Address, peerTy
 
 		// setup peer with high peer type and check all the entities.
 		if peer.PeerType < peerType {
-			p.SetupPeer(peer, peerType, false)
+			p.ResetPeerType(peer, false, false)
 			return nil
 		}
 


### PR DESCRIPTION
More clean-up in peer.

1. Remove close(p.closed) in NewPeer.
2. Use ptt.ResetPeerType instead of ptt.SetupPeer in ptt.AddDial and pm.ApproveJoin. use ptt.SetupPeer only in ptt.FinishIdentifyPeer"