### PR TITLE
git ignore log.tmp.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test.out
 /build/electron/deploy_token
 /build/electron/deploy_token.txt
 /bootnode.local
+log.tmp.txt


### PR DESCRIPTION
`log.tmp.txt` 是測試過程中會產出的 log。應該不需要被 git track？