### PR TITLE
Multiple-fixes in trying to avoid deadlock in NewPeerCh / RegisterPeerToEntities

### DIFF
--- a/account/api.go
+++ b/account/api.go
@@ -66,6 +66,10 @@ func (api *PrivateAPI) RemoveUserNode(entityID string, nodeIDStr string) (types.
 	return api.b.RemoveUserNode([]byte(entityID), []byte(nodeIDStr))
 }
 
+func (api *PrivateAPI) ForceSync(entityID string) (bool, error) {
+	return api.b.ForceSync([]byte(entityID))
+}
+
 /**********
  * Raw Data
  **********/

--- a/account/protocol_handle_user_oplog.go
+++ b/account/protocol_handle_user_oplog.go
@@ -153,9 +153,7 @@ func (pm *ProtocolManager) postprocessUserOplogs(processInfo pkgservice.ProcessI
 	pm.SyncNameCard(SyncUpdateNameCardMsg, updateNameCardIDs, peer)
 
 	// broadcast
-	if isPending {
-		pm.broadcastUserOplogsCore(toBroadcastLogs)
-	}
+	pm.broadcastUserOplogsCore(toBroadcastLogs)
 
 	return
 }

--- a/account/protocol_remove_user_node_logs.go
+++ b/account/protocol_remove_user_node_logs.go
@@ -18,6 +18,7 @@ package account
 
 import (
 	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
 	pkgservice "github.com/ailabstw/go-pttai/service"
 )
 
@@ -26,6 +27,8 @@ func (pm *ProtocolManager) handleRemoveUserNodeLog(oplog *pkgservice.BaseOplog, 
 	pm.SetUserNodeDB(obj)
 
 	opData := &UserOpRemoveUserNode{}
+
+	log.Debug("handleRemoveUserNodeLog: to HandleDeleteObjectLog", "entity", pm.Entity().IDString(), "oplog", oplog)
 
 	toBroadcastLogs, err := pm.HandleDeleteObjectLog(
 		oplog,
@@ -42,6 +45,7 @@ func (pm *ProtocolManager) handleRemoveUserNodeLog(oplog *pkgservice.BaseOplog, 
 		pm.postdeleteUserNode,
 		pm.updateDeleteUserNodeInfo,
 	)
+	log.Debug("handleRemoveUserNodeLog: after HandleDeleteObjectLog", "entity", pm.Entity().IDString(), "oplog", oplog, "e", err)
 	if err != nil {
 		return nil, err
 	}

--- a/account/user_node.go
+++ b/account/user_node.go
@@ -146,7 +146,7 @@ func (u *UserNode) Save(isLocked bool) error {
 		&pttdb.KeyVal{K: idx2Key, V: key},
 	}
 
-	log.Debug("UserNode.Save: to ForcePutAll", "ID", u.ID)
+	log.Debug("UserNode.Save: to ForcePutAll", "ID", u.ID, "nodeID", u.NodeID, "idx2Key", idx2Key, "key", key)
 
 	_, err = u.DB().ForcePutAll(idxKey, idx, kvs)
 	if err != nil {

--- a/common/types/lock_map.go
+++ b/common/types/lock_map.go
@@ -44,6 +44,10 @@ func NewLockMap(sleepTime int) (*LockMap, error) {
 }
 
 func (l *LockMap) TryLock(id *PttID) error {
+	if id == nil {
+		return nil
+	}
+
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -57,6 +61,10 @@ func (l *LockMap) TryLock(id *PttID) error {
 }
 
 func (l *LockMap) Unlock(id *PttID) error {
+	if id == nil {
+		return nil
+	}
+
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -70,6 +78,10 @@ func (l *LockMap) Unlock(id *PttID) error {
 }
 
 func (l *LockMap) TryRLock(id *PttID) error {
+	if id == nil {
+		return nil
+	}
+
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -87,6 +99,10 @@ func (l *LockMap) TryRLock(id *PttID) error {
 }
 
 func (l *LockMap) RUnlock(id *PttID) error {
+	if id == nil {
+		return nil
+	}
+
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -107,6 +123,11 @@ func (l *LockMap) RUnlock(id *PttID) error {
 func (l *LockMap) Lock(id *PttID) error {
 	sleepTime := time.Duration((rand.Intn(l.sleepTime) + 1)) * time.Millisecond
 	var err error
+
+	if id == nil {
+		return nil
+	}
+
 	for i := 0; i < NIterLock; i++ {
 		err = l.TryLock(id)
 		if err == nil {
@@ -130,6 +151,10 @@ func (l *LockMap) MustLock(id *PttID) (err error) {
 }
 
 func (l *LockMap) RLock(id *PttID) error {
+	if id == nil {
+		return nil
+	}
+
 	sleepTime := time.Duration((rand.Intn(l.sleepTime) + 1)) * time.Millisecond
 	var err error
 	for i := 0; i < NIterLock; i++ {

--- a/content/protocol_handle_board_oplog.go
+++ b/content/protocol_handle_board_oplog.go
@@ -227,7 +227,9 @@ func (pm *ProtocolManager) postprocessBoardOplogs(processInfo pkgservice.Process
 		if err != nil {
 			return
 		}
+	}
 
+	if isPending {
 		pm.broadcastBoardOplogsCore(toBroadcastLogs)
 	}
 

--- a/e2e/friend_delete_board2_test.go
+++ b/e2e/friend_delete_board2_test.go
@@ -667,6 +667,8 @@ func TestFriendDeleteBoard2(t *testing.T) {
 
 	time.Sleep(TimeSleepRestart)
 
+	time.Sleep(TimeSleepRestart)
+
 	// 48. content-get-board
 	marshaledID, _ = board1_16_2.ID.MarshalText()
 

--- a/e2e/friend_delete_member3_test.go
+++ b/e2e/friend_delete_member3_test.go
@@ -378,6 +378,8 @@ func TestFriendDeleteMember3(t *testing.T) {
 
 	time.Sleep(TimeSleepDefault)
 
+	time.Sleep(TimeSleepDefault)
+
 	// 16. get board-oplog
 	marshaled, _ = board1_13_1.ID.MarshalText()
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardOplogList", "params": ["%v", "", 0, 2]}`, string(marshaled))

--- a/e2e/friend_delete_member4_test.go
+++ b/e2e/friend_delete_member4_test.go
@@ -637,6 +637,8 @@ func TestFriendDeleteMember4(t *testing.T) {
 	// sleep
 	time.Sleep(TimeSleepRestart)
 
+	time.Sleep(TimeSleepRestart)
+
 	// 23. get board list
 	t.Logf("23. get board list")
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardList", "params": ["", 0, 2]}`)

--- a/e2e/multi_device3_revoke_node_test.go
+++ b/e2e/multi_device3_revoke_node_test.go
@@ -162,7 +162,7 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 
 	// wait 15
 	t.Logf("wait 10 seconds for hand-shaking")
-	time.Sleep(10 * time.Second)
+	time.Sleep(TimeSleepRestart)
 
 	// 7.1
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "me_joinMe", "params": ["%v", "%v", false]}`, meURL1_5, myKey2_4)
@@ -175,7 +175,7 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 
 	// wait 15
 	t.Logf("wait 10 seconds for hand-shaking")
-	time.Sleep(10 * time.Second)
+	time.Sleep(TimeSleepRestart)
 
 	// 8. me_GetMyNodes
 
@@ -224,6 +224,28 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 	assert.Equal(types.StatusAlive, myNode2_8_1.Status)
 	assert.Equal(types.StatusAlive, myNode2_8_2.Status)
 
+	// 9. me_getPeers
+
+	t.Logf("9. me_getPeers")
+	bodyString = `{"id": "testID", "method": "me_getPeers", "params": [""]}`
+	dataGetPeers0_9 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetPeers0_9, t, isDebug)
+	assert.Equal(2, len(dataGetPeers0_9.Result))
+
+	dataGetPeers1_9 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetPeers1_9, t, isDebug)
+	assert.Equal(2, len(dataGetPeers1_9.Result))
+
+	dataGetPeers2_9 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetPeers2_9, t, isDebug)
+	assert.Equal(2, len(dataGetPeers2_9.Result))
+
 	// 10. revoke-node
 	marshaled, _ = me1_1.NodeID.MarshalText()
 	bodyString = fmt.Sprintf(`{"id": "testID", "method": "me_removeNode", "params": ["%v"]}`, string(marshaled))
@@ -233,7 +255,7 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 
 	// wait 10 seconds
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(TimeSleepRestart)
 
 	// 11.0 test-error
 	err = testError("http://127.0.0.1:9450")
@@ -253,9 +275,18 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 	testListCore(t0, bodyString, dataGetMyNodes0_11, t, isDebug)
 	assert.Equal(2, len(dataGetMyNodes0_11.Result))
 	myNode0_11_0 := dataGetMyNodes0_11.Result[0]
+	myNode0_11_1 := dataGetMyNodes0_11.Result[1]
+	myNode0_11_me := myNode0_11_0
+	myNode0_11_other := myNode0_11_1
+
+	if !reflect.DeepEqual(me0_1.NodeID, myNode0_11_0.NodeID) {
+		myNode0_11_me = myNode0_11_1
+		myNode0_11_other = myNode0_11_0
+	}
 
 	assert.Equal(types.StatusAlive, myNode0_11_0.Status)
-	assert.Equal(me0_1.NodeID, myNode0_11_0.NodeID)
+	assert.Equal(me0_1.NodeID, myNode0_11_me.NodeID)
+	assert.Equal(me2_1.NodeID, myNode0_11_other.NodeID)
 
 	// 12. getPeers
 	bodyString = `{"id": "testID", "method": "me_getPeers", "params": [""]}`
@@ -272,6 +303,26 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 	testListCore(t2, bodyString, dataPeers2_12, t, isDebug)
 	assert.Equal(1, len(dataPeers2_12.Result))
 
+	// 12.1 account_getPeers
+	marshaled, _ = profileID1_3.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "account_getPeers", "params": ["%v"]}`, string(marshaled))
+
+	dataPeers0_12_1 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataPeers0_12_1, t, isDebug)
+	assert.Equal(1, len(dataPeers0_12_1.Result))
+	peer0_12_1_0 := dataPeers0_12_1.Result[0]
+	assert.Equal(me2_1.NodeID, peer0_12_1_0.NodeID)
+
+	dataPeers2_12_1 := &struct {
+		Result []*pkgservice.BackendPeer `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataPeers2_12_1, t, isDebug)
+	assert.Equal(1, len(dataPeers2_12_1.Result))
+	peer2_12_1_0 := dataPeers2_12_1.Result[0]
+	assert.Equal(me0_1.NodeID, peer2_12_1_0.NodeID)
+
 	// 13. getPeers
 	bodyString = `{"id": "testID", "method": "ptt_getPeers", "params": []}`
 
@@ -280,6 +331,20 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 	}{}
 	testListCore(t0, bodyString, dataPeers0_13, t, isDebug)
 	assert.Equal(1, len(dataPeers0_13.Result))
+
+	// 10.1. force sync.
+	marshaled, _ = profileID1_3.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "account_forceSync", "params": ["%v"]}`, string(marshaled))
+
+	bool0_10_1 := false
+	testCore(t0, bodyString, &bool0_10_1, t, isDebug)
+	assert.Equal(true, bool0_10_1)
+	time.Sleep(TimeSleepRestart)
+
+	bool2_10_1 := false
+	testCore(t2, bodyString, &bool2_10_1, t, isDebug)
+	assert.Equal(true, bool2_10_1)
+	time.Sleep(TimeSleepRestart)
 
 	// 14. getUserNode
 	t.Logf("10.6 GetUserNodeList")
@@ -303,7 +368,7 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 	dataGetUserNodeList2_14 := &struct {
 		Result []*account.UserNode `json:"result"`
 	}{}
-	testListCore(t0, bodyString, dataGetUserNodeList2_14, t, isDebug)
+	testListCore(t2, bodyString, dataGetUserNodeList2_14, t, isDebug)
 	assert.Equal(3, len(dataGetUserNodeList2_14.Result))
 
 	for _, each := range dataGetUserNodeList2_14.Result {
@@ -322,7 +387,7 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 		Result []*account.UserOplog `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataGetUserOplogList0_15, t, isDebug)
-	assert.Equal(8, len(dataGetUserOplogList0_15.Result))
+	assert.Equal(9, len(dataGetUserOplogList0_15.Result))
 	//assert.Equal(dataGetUserOplogList0_9_4_1.Result, dataGetUserOplogList0_15.Result[:5])
 	userOplog0_15 := dataGetUserOplogList0_15.Result[7]
 	assert.Equal(types.StatusAlive, userOplog0_15.ToStatus())
@@ -334,7 +399,7 @@ func TestMultiDevice3RevokeNode(t *testing.T) {
 		Result []*account.UserOplog `json:"result"`
 	}{}
 	testListCore(t0, bodyString, dataGetUserOplogList2_15, t, isDebug)
-	assert.Equal(8, len(dataGetUserOplogList2_15.Result))
+	assert.Equal(9, len(dataGetUserOplogList2_15.Result))
 	//assert.Equal(dataGetUserOplogList0_9_4_1.Result, dataGetUserOplogList2_15.Result[:5])
 	userOplog2_15 := dataGetUserOplogList2_15.Result[7]
 	assert.Equal(types.StatusAlive, userOplog2_15.ToStatus())

--- a/e2e/multi_device_revoke_node_test.go
+++ b/e2e/multi_device_revoke_node_test.go
@@ -217,7 +217,7 @@ func TestMultiDeviceRevokeNode(t *testing.T) {
 
 	profile0_9_1 := &account.Profile{}
 	testCore(t0, bodyString, profile0_9_1, t, isDebug)
-	assert.Equal(types.StatusDeleted, profile0_9_1.Status)
+	assert.Equal(types.StatusTerminal, profile0_9_1.Status)
 	assert.Equal(me0_3.ID, profile0_9_1.MyID)
 	assert.Equal(me0_3.ProfileID, profile0_9_1.ID)
 	assert.Equal(false, profile0_9_1.IsOwner(me0_1.ID))

--- a/friend/protocol_approve_join_friend.go
+++ b/friend/protocol_approve_join_friend.go
@@ -38,12 +38,6 @@ func (pm *ProtocolManager) ApproveJoinFriend(joinEntity *pkgservice.JoinEntity, 
 	// friend
 	f := pm.Entity().(*Friend)
 
-	// register pending peer
-	if peer.UserID == nil {
-		peer.UserID = joinEntity.ID
-	}
-	pm.RegisterPendingPeer(peer, false)
-
 	// master
 	oplog := &pkgservice.BaseOplog{}
 	pm.SetMasterDB(oplog)
@@ -56,7 +50,7 @@ func (pm *ProtocolManager) ApproveJoinFriend(joinEntity *pkgservice.JoinEntity, 
 	log.Debug("ApproveJoinFriend: after master GetOplogList", "masterLogs", masterLogs)
 
 	// member
-	_, _, err = pm.AddMember(peer.UserID, true)
+	_, _, err = pm.AddMember(joinEntity.ID, true)
 	if err != nil {
 		log.Error("ApproveJoinFriend: unable to add member", "e", err, "entity", pm.Entity().GetID())
 		return nil, nil, err

--- a/friend/protocol_handle_friend_oplog.go
+++ b/friend/protocol_handle_friend_oplog.go
@@ -112,9 +112,7 @@ func (pm *ProtocolManager) postprocessFriendOplogs(processInfo pkgservice.Proces
 
 	pm.SyncBlock(SyncCreateMessageBlockMsg, blockIDs, peer)
 
-	if isPending {
-		pm.broadcastFriendOplogsCore(toBroadcastLogs)
-	}
+	pm.broadcastFriendOplogsCore(toBroadcastLogs)
 
 	// post-delete-friend
 	if !isPending && len(info.FriendInfo) > 0 {

--- a/friend/protocol_manager_utils_handle_message.go
+++ b/friend/protocol_manager_utils_handle_message.go
@@ -21,6 +21,23 @@ import (
 	pkgservice "github.com/ailabstw/go-pttai/service"
 )
 
+func (pm *ProtocolManager) HandleNonRegisteredMessage(op pkgservice.OpType, dataBytes []byte, peer *pkgservice.PttPeer) error {
+
+	log.Debug("friend.HandleNonRegisteredMessage: start", "op", op, "InitFriendInfoMsg", InitFriendInfoMsg)
+
+	err := pkgservice.ErrInvalidMsg
+
+	switch op {
+	// init friend info
+	case InitFriendInfoMsg:
+		err = pm.HandleInitFriendInfo(dataBytes, peer)
+	case InitFriendInfoAckMsg:
+		err = pm.HandleInitFriendInfoAck(dataBytes, peer)
+	}
+
+	return err
+}
+
 func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte, peer *pkgservice.PttPeer) error {
 
 	log.Debug("friend.HandleMessage: start", "op", op, "AddFriendOplogMsg", AddFriendOplogMsg)
@@ -57,12 +74,6 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 		err = pm.HandleAddPendingFriendOplog(dataBytes, peer)
 	case AddPendingFriendOplogsMsg:
 		err = pm.HandleAddPendingFriendOplogs(dataBytes, peer)
-
-	// init friend info
-	case InitFriendInfoMsg:
-		err = pm.HandleInitFriendInfo(dataBytes, peer)
-	case InitFriendInfoAckMsg:
-		err = pm.HandleInitFriendInfoAck(dataBytes, peer)
 
 	// message
 	case SyncCreateMessageMsg:

--- a/me/protocol_approve_join_friend.go
+++ b/me/protocol_approve_join_friend.go
@@ -62,6 +62,13 @@ func (pm *ProtocolManager) ApproveJoinFriend(joinEntity *pkgservice.JoinEntity, 
 		return nil, nil, err
 	}
 
+	// register pending peer
+	if peer.UserID == nil {
+		peer.UserID = joinEntity.ID
+		friendPM.Ptt().FinishIdentifyPeer(peer, false, false)
+	}
+	friendPM.RegisterPendingPeer(peer, false)
+
 	data := &ApproveJoinFriend{
 		FriendData: friendData.(*friend.ApproveJoin),
 	}
@@ -169,6 +176,7 @@ func (pm *ProtocolManager) HandleApproveJoinFriend(dataBytes []byte, joinRequest
 	// register-peer
 	if peer.UserID == nil {
 		peer.UserID = f.FriendID
+		newPM.Ptt().FinishIdentifyPeer(peer, false, false)
 	}
 	newPM.RegisterPendingPeer(peer, false)
 

--- a/me/protocol_approve_join_me.go
+++ b/me/protocol_approve_join_me.go
@@ -167,12 +167,12 @@ func (pm *ProtocolManager) HandleApproveJoinMe(dataBytes []byte, joinRequest *pk
 	}
 
 	// register peer
-	log.Debug("HandleApproveJoinMe: to RegisterPeer")
+	log.Debug("HandleApproveJoinMe: to RegisterPendingPeer")
 
 	peer.UserID = newMyInfo.ID
 	newPM.RegisterPendingPeer(peer, false)
 
-	log.Debug("HandleApproveJoinMe: after RegisterPeer")
+	log.Debug("HandleApproveJoinMe: after RegisterPendingPeer")
 
 	// add to entities
 	log.Debug("HandleApproveJoinMe: to RegisterEntity")

--- a/me/protocol_handle_me_oplog.go
+++ b/me/protocol_handle_me_oplog.go
@@ -119,8 +119,9 @@ func (pm *ProtocolManager) postprocessMeOplogs(processInfo pkgservice.ProcessInf
 
 	if isPending {
 		toBroadcastLogs = pkgservice.ProcessInfoToBroadcastLogs(info.DeleteMeInfo, toBroadcastLogs)
-		pm.broadcastMeOplogsCore(toBroadcastLogs)
 	}
+
+	pm.broadcastMeOplogsCore(toBroadcastLogs)
 
 	return
 }

--- a/me/protocol_internal_sync_friend.go
+++ b/me/protocol_internal_sync_friend.go
@@ -227,9 +227,6 @@ func (pm *ProtocolManager) handleInternalSyncFriendAckNew(
 	}
 
 	// register-peer
-	if peer.UserID == nil {
-		peer.UserID = f.FriendID
-	}
 	friendPM.RegisterPendingPeer(peer, false)
 
 	// add to entity

--- a/me/protocol_manager_utils_handle_message.go
+++ b/me/protocol_manager_utils_handle_message.go
@@ -21,10 +21,7 @@ import (
 	pkgservice "github.com/ailabstw/go-pttai/service"
 )
 
-func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte, peer *pkgservice.PttPeer) (err error) {
-
-	myInfo := pm.Entity().(*MyInfo)
-	log.Debug("HandleMessage: Received msg", "myID", myInfo.ID, "op", op, "SyncMeOplogMsg", SyncMeOplogMsg, "peer", peer, "peerType", peer.PeerType)
+func (pm *ProtocolManager) HandleNonRegisteredMessage(op pkgservice.OpType, dataBytes []byte, peer *pkgservice.PttPeer) (err error) {
 
 	switch op {
 	// init me info
@@ -39,6 +36,14 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SendRaftMsgsMsg:
 		return pm.HandleSendRaftMsgs(dataBytes, peer)
 	}
+
+	return pkgservice.ErrInvalidMsg
+}
+
+func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte, peer *pkgservice.PttPeer) (err error) {
+
+	myInfo := pm.Entity().(*MyInfo)
+	log.Debug("HandleMessage: Received msg", "myID", myInfo.ID, "op", op, "SyncMeOplogMsg", SyncMeOplogMsg, "peer", peer, "peerType", peer.PeerType)
 
 	fitPeerType := pm.GetPeerType(peer)
 

--- a/service/merkle.go
+++ b/service/merkle.go
@@ -710,7 +710,7 @@ func (m *Merkle) SetUpdateTS(ts types.Timestamp) error {
 	m.lockToUpdateTS.Lock()
 	defer m.lockToUpdateTS.Unlock()
 
-	key := m.MarshalToUpdateTSKey(ts)
+	key := m.MarshalToUpdateTSKey(hrTS)
 
 	m.db.DB().Put(key, merkleToUpdateTSValue)
 
@@ -729,11 +729,11 @@ func (m *Merkle) SetUpdateTS2(ts types.Timestamp, ts2 types.Timestamp) error {
 	m.toUpdateTS[hrTS.Ts] = true
 	m.toUpdateTS[hrTS2.Ts] = true
 
-	key := m.MarshalToUpdateTSKey(ts)
+	key := m.MarshalToUpdateTSKey(hrTS)
 
 	m.db.DB().Put(key, merkleToUpdateTSValue)
 
-	key = m.MarshalToUpdateTSKey(ts2)
+	key = m.MarshalToUpdateTSKey(hrTS2)
 
 	m.db.DB().Put(key, merkleToUpdateTSValue)
 

--- a/service/protocol_approve_join_entity.go
+++ b/service/protocol_approve_join_entity.go
@@ -110,6 +110,7 @@ func (pm *BaseProtocolManager) ApproveJoin(
 	// register-peer
 	if peer.UserID == nil {
 		peer.UserID = joinEntity.ID
+		pm.Ptt().FinishIdentifyPeer(peer, false, false)
 	}
 
 	switch {

--- a/service/protocol_identify_peer_ack.go
+++ b/service/protocol_identify_peer_ack.go
@@ -121,7 +121,7 @@ HandleIdentifyPeerAck
 */
 func (p *BasePtt) HandleIdentifyPeerAck(entityID *types.PttID, data *IdentifyPeerAck, peer *PttPeer) error {
 
-	if !reflect.DeepEqual(peer.IDChallenge[:], data.AckChallenge[:types.SizeSalt]) {
+	if peer.IDChallenge == nil || data.AckChallenge == nil || !reflect.DeepEqual(peer.IDChallenge[:], data.AckChallenge[:types.SizeSalt]) {
 		log.Warn("HandleIdentifyPeerAck: unable to match challenge", "peer", peer.IDChallenge, "data", data.AckChallenge, "peer", peer)
 		return ErrInvalidData
 	}

--- a/service/protocol_manager.go
+++ b/service/protocol_manager.go
@@ -36,6 +36,7 @@ type ProtocolManager interface {
 	Stop() error
 	Poststop() error
 
+	HandleNonRegisteredMessage(op OpType, dataBytes []byte, peer *PttPeer) error
 	HandleMessage(op OpType, dataBytes []byte, peer *PttPeer) error
 
 	Sync(peer *PttPeer) error
@@ -661,6 +662,10 @@ func NewBaseProtocolManager(
 
 	return pm, nil
 
+}
+
+func (pm *BaseProtocolManager) HandleNonRegisteredMessage(op OpType, dataBytes []byte, peer *PttPeer) error {
+	return types.ErrNotImplemented
 }
 
 func (pm *BaseProtocolManager) HandleMessage(op OpType, dataBytes []byte, peer *PttPeer) error {

--- a/service/protocol_manager_utils_op_key.go
+++ b/service/protocol_manager_utils_op_key.go
@@ -293,6 +293,10 @@ func (pm *BaseProtocolManager) RemoveOpKeyFromHash(
 	isDeleteDB bool,
 ) error {
 
+	if hash == nil {
+		return nil
+	}
+
 	if !isLocked {
 		pm.lockOpKeyInfo.Lock()
 		defer pm.lockOpKeyInfo.Unlock()

--- a/service/protocol_manager_utils_sync.go
+++ b/service/protocol_manager_utils_sync.go
@@ -39,54 +39,62 @@ looping:
 				break looping
 			}
 
-			log.Debug("PMSync: NewPeerCh: start", "entity", pm.Entity().IDString())
+			log.Info("PMSync: NewPeerCh: start", "entity", pm.Entity().IDString(), "peer", peer)
 
 			pm.SyncOpKeyOplog(peer, SyncOpKeyOplogMsg)
 			err = pm.Sync(peer)
-			log.Debug("PMSync: NewPeerCh: after pm.Sync", "entity", pm.Entity(), "peer", peer, "e", err)
+			log.Info("PMSync: NewPeerCh: after pm.Sync", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 			if err != nil {
-				log.Error("unable to Sync after newPeer", "e", err, "peer", peer, "entity", pm.Entity().IDString())
+				log.Error("PMSync: unable to Sync after newPeer", "e", err, "peer", peer, "entity", pm.Entity().IDString())
 
 				if err == p2p.ErrPeerShutdown {
 					pm.UnregisterPeer(peer, false, true, false)
 				}
 			}
+			log.Info("PMSync: NewPeerCh: done", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 		case <-pm.ForceSync():
-			log.Debug("PMSync: ForceSync: start", "entity", pm.Entity().IDString())
+			log.Info("PMSync: ForceSync: start", "entity", pm.Entity().IDString())
 			peer, err = pmSyncPeer(pm)
-			log.Debug("PMSync: ForceSync: after pmSyncPeer", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
+			log.Info("PMSync: ForceSync: after pmSyncPeer", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 			if err != nil {
 				break looping
 			}
 
 			pm.SyncOpKeyOplog(peer, SyncOpKeyOplogMsg)
-			log.Debug("PMSync: ForceSync: to Sync", "entity", pm.Entity().IDString(), "peer", peer)
+			log.Info("PMSync: ForceSync: to Sync", "entity", pm.Entity().IDString(), "peer", peer)
 			err = pm.Sync(peer)
-			log.Debug("PMSync: ForceSync: after Sync", "entity", pm.Entity().IDString(), "peer", peer)
+			log.Info("PMSync: ForceSync: after Sync", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 			if err != nil {
-				log.Error("unable to Sync after forceSync", "e", err, "peer", peer, "entity", pm.Entity().IDString())
+				log.Error("PMSync: unable to Sync after forceSync", "e", err, "peer", peer, "entity", pm.Entity().IDString())
 				if err == p2p.ErrPeerShutdown {
 					pm.UnregisterPeer(peer, false, true, false)
 				}
 			}
+			log.Info("PMSync: ForceSync: done", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 
 		case <-forceSyncTicker.C:
 			forceSyncTicker.Stop()
 			forceSyncTicker = time.NewTicker(pm.ForceSyncCycle())
 
+			log.Info("PMSync: ticker: start", "entity", pm.Entity().IDString())
+
 			peer, err = pmSyncPeer(pm)
+			log.Info("PMSync: ticker: after pmSyncPeer", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 			if err != nil {
 				break looping
 			}
 
 			pm.SyncOpKeyOplog(peer, SyncOpKeyOplogMsg)
+			log.Info("PMSync: ticker: to Sync", "entity", pm.Entity().IDString(), "peer", peer)
 			err = pm.Sync(peer)
+			log.Info("PMSync: ticker: after pm.Sync", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 			if err != nil {
-				log.Error("unable to Sync after forceSyncTicker", "e", err, "peer", peer, "entity", pm.Entity().IDString())
+				log.Error("PMSync: unable to Sync after ticker", "e", err, "peer", peer, "entity", pm.Entity().IDString())
 				if err == p2p.ErrPeerShutdown {
 					pm.UnregisterPeer(peer, false, true, false)
 				}
 			}
+			log.Info("PMSync: ticker: done", "entity", pm.Entity().IDString(), "peer", peer, "e", err)
 		case <-pm.QuitSync():
 			log.Info("PMSync: QuitSync", "entity", pm.Entity().IDString())
 			err = p2p.DiscQuitting

--- a/service/protocol_request_op_key.go
+++ b/service/protocol_request_op_key.go
@@ -85,6 +85,8 @@ func (p *BasePtt) HandleRequestOpKey(dataBytes []byte, peer *PttPeer) error {
 	}
 	pm := entity.PM()
 
+	log.Debug("HandleRequestOpKey: to check status", "entity", pm.Entity().IDString(), "status", entity.GetStatus())
+
 	if entity.GetStatus() >= types.StatusMigrated {
 		return p.EntityTerminal(entity, pm, peer)
 	}

--- a/service/protocol_sync_op_key_oplog.go
+++ b/service/protocol_sync_op_key_oplog.go
@@ -45,6 +45,10 @@ func (pm *BaseProtocolManager) SyncOpKeyOplog(peer *PttPeer, syncMsg OpType) err
 		return nil
 	}
 
+	if !peer.IsRegistered {
+		return nil
+	}
+
 	data := &SyncOpKeyOplog{
 		Oplogs: oplogs,
 	}

--- a/service/protocol_sync_oplog.go
+++ b/service/protocol_sync_oplog.go
@@ -36,6 +36,15 @@ Expected merkle-tree-list length: 24 (hour) + 31 (day) + 12 (month) + n (year)
 (should be within the packet-limit)
 */
 func (pm *BaseProtocolManager) SyncOplog(peer *PttPeer, merkle *Merkle, op OpType) error {
+
+	if peer == nil {
+		return nil
+	}
+
+	if !peer.IsRegistered {
+		return nil
+	}
+
 	ptt := pm.Ptt()
 	myInfo := ptt.GetMyEntity()
 	if myInfo.GetStatus() != types.StatusAlive {

--- a/service/protocol_sync_oplog_ack.go
+++ b/service/protocol_sync_oplog_ack.go
@@ -59,12 +59,6 @@ func (pm *BaseProtocolManager) SyncOplogAck(
 
 	offsetHourTS, _ := myToSyncTime.ToHRTimestamp()
 
-	err := pm.ForceSyncOplogAck(toSyncTime, offsetHourTS, merkle, forceSyncOplogAckMsg, peer)
-	log.Debug("SyncOplogAck: after ForceSyncOplogAck", "toSyncTime", toSyncTime, "offsetHourTS", offsetHourTS, "e", err, "entity", pm.Entity().GetID())
-	if err != nil {
-		return err
-	}
-
 	now, err := types.GetTimestamp()
 	if err != nil {
 		return err

--- a/service/protocol_sync_oplog_invalid_ack.go
+++ b/service/protocol_sync_oplog_invalid_ack.go
@@ -18,8 +18,6 @@ package service
 
 import (
 	"bytes"
-	"encoding/json"
-	"math/rand"
 
 	"github.com/ailabstw/go-pttai/common/types"
 )
@@ -51,28 +49,32 @@ func (pm *BaseProtocolManager) SyncOplogInvalidAck(
 	invalidOplogMsg OpType,
 ) error {
 
+	return types.ErrNotImplemented
+
 	// my devices
+	/*
 
-	isToSyncPeer := pm.syncOplogInvalidAckIsToSyncPeer(peer, theirSyncTS, mySyncTS)
+		isToSyncPeer := pm.syncOplogInvalidAckIsToSyncPeer(peer, theirSyncTS, mySyncTS)
 
-	if isToSyncPeer {
-		return pm.ForceSyncOplog(fromSyncTS, toSyncTS, merkle, forceSyncOplogMsg, peer)
-	}
+		if isToSyncPeer {
+			return pm.ForceSyncOplog(fromSyncTS, toSyncTS, merkle, forceSyncOplogMsg, peer)
+		}
 
-	data := &SyncOplogAckInvalid{
-		FromTS: fromSyncTS,
-		ToTS:   toSyncTS,
-	}
+		data := &SyncOplogAckInvalid{
+			FromTS: fromSyncTS,
+			ToTS:   toSyncTS,
+		}
 
-	pm.SendDataToPeer(invalidOplogMsg, data, peer)
+		pm.SendDataToPeer(invalidOplogMsg, data, peer)
 
-	myID := pm.Ptt().GetMyEntity().GetID()
-	if peer.PeerType != PeerTypeMe && !pm.IsMaster(myID, false) && !pm.IsMaster(peer.UserID, false) {
+		myID := pm.Ptt().GetMyEntity().GetID()
+		if peer.PeerType != PeerTypeMe && !pm.IsMaster(myID, false) && !pm.IsMaster(peer.UserID, false) {
 
-		pm.UnregisterPeer(peer, false, false, false)
-	}
+			pm.UnregisterPeer(peer, false, false, false)
+		}
 
-	return nil
+		return nil
+	*/
 }
 
 /*
@@ -148,39 +150,43 @@ func (pm *BaseProtocolManager) HandleSyncOplogInvalidAck(
 	forceSyncOplogMsg OpType,
 ) error {
 
-	data := &SyncOplogAckInvalid{}
-	err := json.Unmarshal(dataBytes, data)
-	if err != nil {
-		return err
-	}
+	return types.ErrNotImplemented
 
-	myID := pm.Ptt().GetMyEntity().GetID()
+	/*
+		data := &SyncOplogAckInvalid{}
+		err := json.Unmarshal(dataBytes, data)
+		if err != nil {
+			return err
+		}
 
-	isMe := peer.PeerType == PeerTypeMe
-	isMeMaster := pm.IsMaster(myID, false)
-	isPeerMaster := pm.IsMaster(peer.UserID, false)
+		myID := pm.Ptt().GetMyEntity().GetID()
 
-	// 1. the peer is PeerTypeMe or the peer is master
-	if isMe || isPeerMaster {
-		return pm.ForceSyncOplog(data.FromTS, data.ToTS, merkle, forceSyncOplogMsg, peer)
-	}
+		isMe := peer.PeerType == PeerTypeMe
+		isMeMaster := pm.IsMaster(myID, false)
+		isPeerMaster := pm.IsMaster(peer.UserID, false)
 
-	// 2. I am the master and the peer is not master.
-	if isMeMaster {
-		return ErrInvalidOp
-	}
+		// 1. the peer is PeerTypeMe or the peer is master
+		if isMe || isPeerMaster {
+			return pm.ForceSyncOplog(data.FromTS, data.ToTS, merkle, forceSyncOplogMsg, peer)
+		}
 
-	// 3. I am connecting to the master.
-	masterPeerList := pm.Peers().ImportantPeerList(false)
-	lenMasterPeerList := len(masterPeerList)
-	if lenMasterPeerList > 0 {
-		randIdx := rand.Intn(lenMasterPeerList)
-		masterPeer := masterPeerList[randIdx]
-		return pm.ForceSyncOplog(data.FromTS, data.ToTS, merkle, forceSyncOplogMsg, masterPeer)
-	}
+		// 2. I am the master and the peer is not master.
+		if isMeMaster {
+			return ErrInvalidOp
+		}
 
-	// 4. try to connect the master-node.
-	pm.ConnectMaster()
+		// 3. I am connecting to the master.
+		masterPeerList := pm.Peers().ImportantPeerList(false)
+		lenMasterPeerList := len(masterPeerList)
+		if lenMasterPeerList > 0 {
+			randIdx := rand.Intn(lenMasterPeerList)
+			masterPeer := masterPeerList[randIdx]
+			return pm.ForceSyncOplog(data.FromTS, data.ToTS, merkle, forceSyncOplogMsg, masterPeer)
+		}
 
-	return nil
+		// 4. try to connect the master-node.
+		pm.ConnectMaster()
+
+		return nil
+	*/
 }

--- a/service/ptt.go
+++ b/service/ptt.go
@@ -107,9 +107,8 @@ type MyPtt interface {
 
 	// SetPeerType
 
-	SetupPeer(peer *PttPeer, peerType PeerType, isLocked bool) error
-
 	SetPeerType(peer *PttPeer, peerType PeerType, isForce bool, isLocked bool) error
+	SetupPeer(peer *PttPeer, peerType PeerType, isLocked bool) error
 
 	GetEntities() map[types.PttID]Entity
 }

--- a/service/ptt_peer.go
+++ b/service/ptt_peer.go
@@ -48,6 +48,8 @@ type PttPeer struct {
 	IDChallenge *types.Salt
 	IDChan      chan struct{}
 
+	IsRegistered bool
+
 	IsToClose bool
 }
 

--- a/service/ptt_peer_set.go
+++ b/service/ptt_peer_set.go
@@ -215,14 +215,31 @@ func (ps *PttPeerSet) Unregister(peer *PttPeer, isLocked bool) error {
 		return ErrNotRegistered
 	}
 
+	var origPeer *PttPeer
 	switch origPeerType {
 	case PeerTypeMe:
+		origPeer, ok = ps.mePeers[id]
+		if !ok || origPeer != peer {
+			return ErrNotRegistered
+		}
 		delete(ps.mePeers, id)
 	case PeerTypeImportant:
+		origPeer, ok = ps.importantPeers[id]
+		if !ok || origPeer != peer {
+			return ErrNotRegistered
+		}
 		delete(ps.importantPeers, id)
 	case PeerTypeMember:
+		origPeer, ok = ps.memberPeers[id]
+		if !ok || origPeer != peer {
+			return ErrNotRegistered
+		}
 		delete(ps.memberPeers, id)
 	case PeerTypePending:
+		origPeer, ok = ps.pendingPeers[id]
+		if !ok || origPeer != peer {
+			return ErrNotRegistered
+		}
 		delete(ps.pendingPeers, id)
 	}
 

--- a/service/ptt_utils_entity.go
+++ b/service/ptt_utils_entity.go
@@ -168,7 +168,7 @@ func (p *BasePtt) registerEntityPeers(e Entity, isLocked bool) error {
 
 	// pending-peers
 	toRemovePeers = make([]*discover.NodeID, 0)
-	log.Debug("registerEntityPeers: to pendingPeers")
+	log.Debug("registerEntityPeers: to pendingPeers", "pendingPeers", len(p.pendingPeers))
 	for _, peer = range p.pendingPeers {
 		if pm.IsMyDevice(peer) {
 			pm.RegisterPeer(peer, PeerTypeMe, false)

--- a/service/ptt_utils_handle_message.go
+++ b/service/ptt_utils_handle_message.go
@@ -33,11 +33,12 @@ func (p *BasePtt) HandleMessageWrapper(peer *PttPeer) error {
 		log.Error("HandleMessageWrapper: unable ReadMsg", "peer", peer, "e", err)
 		return err
 	}
+	defer msg.Discard()
+
 	if msg.Size > ProtocolMaxMsgSize {
 		log.Error("HandleMessageWrapper: exceed size", "peer", peer, "msg.Size", msg.Size)
 		return ErrMsgTooLarge
 	}
-	defer msg.Discard()
 
 	data := &PttData{}
 	err = msg.Decode(data)


### PR DESCRIPTION
1. Remove SyncOplogInvalidAck
2. msg.Discard in ptt.HandleMessageWrapper.
3. hrTS in merkle.SetUpdateTS
4. defensive programming in ps.Unregister
5. defensive programming in HandleIdentifyPeerAck
6. defensive programming in unset-peer-type
7. HandleNonRegisteredMessage
8. IsRegistered in PttPeer
9. pm.checkOrigPeerAndRegister
10. defensive programming in sync-oplog (peer.IsRegistered)
11. ptt.FinishIdentifyPeer in approve-join-friend.
12. early-defensive-programming in FinishIdentifyPeer
13. account_forceSync.
14. boardcastLog in postprocessLog.
15. ptt.FinishIdentifyPeer in approve_join_entity