### PR TITLE
Sync oplog invalid by merkle.

### DIFF
--- a/account/api.go
+++ b/account/api.go
@@ -50,6 +50,10 @@ func (api *PrivateAPI) GetUserOplogMerkleNodeList(profileID string, level uint8,
 	return api.b.GetUserOplogMerkleNodeList([]byte(profileID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncUserMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncUserMerkle([]byte(entityID))
+}
+
 /**********
  * UserNode
  **********/
@@ -110,6 +114,10 @@ func (api *PrivateAPI) GetMasterOplogMerkleNodeList(profileID string, level uint
 	return api.b.GetMasterOplogMerkleNodeList([]byte(profileID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncMasterMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMasterMerkle([]byte(entityID))
+}
+
 /**********
  * MemberOplog
  **********/
@@ -128,6 +136,10 @@ func (api *PrivateAPI) GetPendingMemberOplogInternalList(profileID string, logID
 
 func (api *PrivateAPI) GetMemberOplogMerkleNodeList(profileID string, level uint8, startKey []byte, limit int, listOrder pttdb.ListOrder) ([]*pkgservice.BackendMerkleNode, error) {
 	return api.b.GetMemberOplogMerkleNodeList([]byte(profileID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
+}
+
+func (api *PrivateAPI) ForceSyncMemberMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMemberMerkle([]byte(entityID))
 }
 
 /**********

--- a/account/backend_core.go
+++ b/account/backend_core.go
@@ -104,6 +104,16 @@ func (b *Backend) GetUserOplogMerkleNodeList(entityIDBytes []byte, level pkgserv
 	return results, nil
 }
 
+func (b *Backend) ForceSyncUserMerkle(entityIDBytes []byte) (bool, error) {
+	thePM, err := b.EntityIDToPM(entityIDBytes)
+	if err != nil {
+		return false, err
+	}
+	pm := thePM.(*ProtocolManager)
+
+	return pm.ForceSyncUserMerkle()
+}
+
 /**********
  * User Node
  **********/

--- a/account/globals.go
+++ b/account/globals.go
@@ -42,12 +42,17 @@ const (
 	AddPendingUserOplogsMsg
 
 	SyncUserOplogMsg
-	ForceSyncUserOplogMsg
-	ForceSyncUserOplogAckMsg
-	InvalidSyncUserOplogMsg
 	SyncUserOplogAckMsg
 	SyncUserOplogNewOplogsMsg
 	SyncUserOplogNewOplogsAckMsg
+
+	InvalidSyncUserOplogMsg
+
+	ForceSyncUserOplogMsg
+	ForceSyncUserOplogAckMsg
+	ForceSyncUserOplogByMerkleMsg
+	ForceSyncUserOplogByMerkleAckMsg
+	ForceSyncUserOplogByOplogAckMsg
 
 	SyncPendingUserOplogMsg // 50
 	SyncPendingUserOplogAckMsg

--- a/account/profile.go
+++ b/account/profile.go
@@ -83,7 +83,7 @@ func (p *Profile) Init(ptt pkgservice.Ptt, service pkgservice.Service, spm pkgse
 }
 
 func (p *Profile) InitPM(ptt pkgservice.Ptt, service pkgservice.Service) error {
-	pm, err := NewProtocolManager(p, ptt)
+	pm, err := NewProtocolManager(p, ptt, service)
 	if err != nil {
 		log.Error("InitPM: unable to NewProtocolManager", "e", err)
 		return err

--- a/account/protocol_handle_user_oplog.go
+++ b/account/protocol_handle_user_oplog.go
@@ -153,7 +153,10 @@ func (pm *ProtocolManager) postprocessUserOplogs(processInfo pkgservice.ProcessI
 	pm.SyncNameCard(SyncUpdateNameCardMsg, updateNameCardIDs, peer)
 
 	// broadcast
-	pm.broadcastUserOplogsCore(toBroadcastLogs)
+	myID := pm.Ptt().GetMyEntity().GetID()
+	if isPending || pm.IsMaster(myID, false) {
+		pm.broadcastUserOplogsCore(toBroadcastLogs)
+	}
 
 	return
 }

--- a/account/protocol_handle_user_oplogs.go
+++ b/account/protocol_handle_user_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncUserOplog(dataBytes []byte, peer *pkgservic
 
 		pm.userOplogMerkle,
 
-		ForceSyncUserOplogMsg,
-		ForceSyncUserOplogAckMsg,
+		ForceSyncUserOplogByMerkleMsg,
+		ForceSyncUserOplogByMerkleAckMsg,
 		InvalidSyncUserOplogMsg,
 		SyncUserOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncUserOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncUserOplogByMerkleAckMsg,
+		ForceSyncUserOplogByOplogAckMsg,
+
+		pm.SetUserDB,
+		pm.SetNewestUserOplog,
+
+		pm.userOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncUserOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncUserOplogByMerkleMsg,
+
+		pm.userOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncUserOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleUserOplogs,
+
+		pm.userOplogMerkle,
 	)
 }
 
@@ -86,9 +123,9 @@ func (pm *ProtocolManager) HandleForceSyncUserOplogAck(dataBytes []byte, peer *p
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncUserOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncUserOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 

--- a/account/protocol_manager_utils_handle_message.go
+++ b/account/protocol_manager_utils_handle_message.go
@@ -30,12 +30,19 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncUserOplogMsg:
 		err = pm.HandleSyncUserOplog(dataBytes, peer)
 
+	case ForceSyncUserOplogByMerkleMsg:
+		return pm.HandleForceSyncUserOplogByMerkle(dataBytes, peer)
+	case ForceSyncUserOplogByMerkleAckMsg:
+		return pm.HandleForceSyncUserOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncUserOplogByOplogAckMsg:
+		return pm.HandleForceSyncUserOplogByOplogAck(dataBytes, peer)
+	case InvalidSyncUserOplogMsg:
+		err = pm.HandleSyncUserOplogInvalid(dataBytes, peer)
+
 	case ForceSyncUserOplogMsg:
 		err = pm.HandleForceSyncUserOplog(dataBytes, peer)
 	case ForceSyncUserOplogAckMsg:
 		err = pm.HandleForceSyncUserOplogAck(dataBytes, peer)
-	case InvalidSyncUserOplogMsg:
-		err = pm.HandleSyncUserOplogInvalidAck(dataBytes, peer)
 
 	case SyncUserOplogAckMsg:
 		err = pm.HandleSyncUserOplogAck(dataBytes, peer)

--- a/account/protocol_sync_user_oplog.go
+++ b/account/protocol_sync_user_oplog.go
@@ -39,3 +39,12 @@ func (pm *ProtocolManager) SyncUserOplog(peer *pkgservice.PttPeer) error {
 func (pm *ProtocolManager) SyncPendingUserOplog(peer *pkgservice.PttPeer) error {
 	return pm.SyncPendingOplog(peer, pm.SetUserDB, pm.HandleFailedUserOplog, SyncPendingUserOplogMsg)
 }
+
+func (pm *ProtocolManager) ForceSyncUserMerkle() (bool, error) {
+	err := pm.userOplogMerkle.TryForceSync(pm)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/build/electron/package.json
+++ b/build/electron/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ptt.ai",
-  "description": "ptt.ai electron packaging",
+  "description": "PTT.ai electron packaging",
   "author": "Yi-Sheng Hsieh <sammui@ailabs.tw>",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "main": "./app/index.js",
   "scripts": {
     "start": "npm install && cross-env NODE_ENV=dev electron ./app",
@@ -17,7 +17,7 @@
   "repository": "https://github.com/ailabstw/go-pttai",
   "build": {
     "appId": "ai.ptt.gptt",
-    "productName": "Pttai",
+    "productName": "PTTai",
     "extraResources": [
       "./app/gptt",
       "./app/gptt.exe",

--- a/content/api.go
+++ b/content/api.go
@@ -248,6 +248,10 @@ func (api *PrivateAPI) GetBoardOplogMerkleNodeList(entityID string, level uint8,
 	return api.b.GetBoardOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncBoardMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncBoardMerkle([]byte(entityID))
+}
+
 func (api *PrivateAPI) GetBoardOplogMerkle(entityID string) (*pkgservice.BackendMerkle, error) {
 	return api.b.GetBoardOplogMerkle([]byte(entityID))
 }
@@ -304,6 +308,10 @@ func (api *PrivateAPI) GetMasterOplogMerkleNodeList(entityID string, level uint8
 	return api.b.GetMasterOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncMasterMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMasterMerkle([]byte(entityID))
+}
+
 /**********
  * MemberOplog
  **********/
@@ -322,6 +330,10 @@ func (api *PrivateAPI) GetPendingMemberOplogInternalList(entityID string, logID 
 
 func (api *PrivateAPI) GetMemberOplogMerkleNodeList(entityID string, level uint8, startKey []byte, limit int, listOrder pttdb.ListOrder) ([]*pkgservice.BackendMerkleNode, error) {
 	return api.b.GetMemberOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
+}
+
+func (api *PrivateAPI) ForceSyncMemberMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMemberMerkle([]byte(entityID))
 }
 
 /**********

--- a/content/backend_core.go
+++ b/content/backend_core.go
@@ -501,6 +501,16 @@ func (b *Backend) GetBoardOplogMerkleNodeList(entityIDBytes []byte, level pkgser
 	return results, nil
 }
 
+func (b *Backend) ForceSyncBoardMerkle(entityIDBytes []byte) (bool, error) {
+	thePM, err := b.EntityIDToPM(entityIDBytes)
+	if err != nil {
+		return false, err
+	}
+	pm := thePM.(*ProtocolManager)
+
+	return pm.ForceSyncBoardMerkle()
+}
+
 func (b *Backend) GetBoardOplogMerkle(entityIDBytes []byte) (*pkgservice.BackendMerkle, error) {
 	thePM, err := b.EntityIDToPM(entityIDBytes)
 	if err != nil {

--- a/content/board.go
+++ b/content/board.go
@@ -88,7 +88,7 @@ func (b *Board) Init(ptt pkgservice.Ptt, service pkgservice.Service, spm pkgserv
 }
 
 func (b *Board) InitPM(ptt pkgservice.Ptt, service pkgservice.Service) error {
-	pm, err := NewProtocolManager(b, ptt)
+	pm, err := NewProtocolManager(b, ptt, service)
 	if err != nil {
 		log.Error("InitPM: unable to NewProtocolManager", "e", err)
 		return err

--- a/content/globals.go
+++ b/content/globals.go
@@ -37,7 +37,7 @@ var (
 // protocol
 const (
 	_ pkgservice.OpType = iota + pkgservice.NMsg
-	// friend-oplog
+	// board-oplog
 	AddBoardOplogMsg //30
 	AddBoardOplogsMsg
 
@@ -45,12 +45,17 @@ const (
 	AddPendingBoardOplogsMsg
 
 	SyncBoardOplogMsg
-	ForceSyncBoardOplogMsg
-	ForceSyncBoardOplogAckMsg
-	InvalidSyncBoardOplogMsg
 	SyncBoardOplogAckMsg
 	SyncBoardOplogNewOplogsMsg
 	SyncBoardOplogNewOplogsAckMsg
+
+	InvalidSyncBoardOplogMsg
+
+	ForceSyncBoardOplogMsg
+	ForceSyncBoardOplogAckMsg
+	ForceSyncBoardOplogByMerkleMsg
+	ForceSyncBoardOplogByMerkleAckMsg
+	ForceSyncBoardOplogByOplogAckMsg
 
 	SyncPendingBoardOplogMsg
 	SyncPendingBoardOplogAckMsg

--- a/content/protocol_create_article.go
+++ b/content/protocol_create_article.go
@@ -70,6 +70,8 @@ func (pm *ProtocolManager) CreateArticle(title []byte, articleBytes [][]byte, me
 		return nil, pkgservice.ErrInvalidData
 	}
 
+	log.Debug("CreateArticle: done", "entity", pm.Entity().IDString())
+
 	return article, nil
 }
 

--- a/content/protocol_handle_board_oplog.go
+++ b/content/protocol_handle_board_oplog.go
@@ -229,7 +229,8 @@ func (pm *ProtocolManager) postprocessBoardOplogs(processInfo pkgservice.Process
 		}
 	}
 
-	if isPending {
+	myID := pm.Ptt().GetMyEntity().GetID()
+	if isPending || pm.IsMaster(myID, false) {
 		pm.broadcastBoardOplogsCore(toBroadcastLogs)
 	}
 

--- a/content/protocol_handle_board_oplogs.go
+++ b/content/protocol_handle_board_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncBoardOplog(dataBytes []byte, peer *pkgservi
 
 		pm.boardOplogMerkle,
 
-		ForceSyncBoardOplogMsg,
-		ForceSyncBoardOplogAckMsg,
+		ForceSyncBoardOplogByMerkleMsg,
+		ForceSyncBoardOplogByMerkleAckMsg,
 		InvalidSyncBoardOplogMsg,
 		SyncBoardOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncBoardOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncBoardOplogByMerkleAckMsg,
+		ForceSyncBoardOplogByOplogAckMsg,
+
+		pm.SetBoardDB,
+		pm.SetNewestBoardOplog,
+
+		pm.boardOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncBoardOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncBoardOplogByMerkleMsg,
+
+		pm.boardOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncBoardOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleBoardOplogs,
+
+		pm.boardOplogMerkle,
 	)
 }
 
@@ -86,9 +123,9 @@ func (pm *ProtocolManager) HandleForceSyncBoardOplogAck(dataBytes []byte, peer *
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncBoardOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncBoardOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 

--- a/content/protocol_manager_utils_handle_message.go
+++ b/content/protocol_manager_utils_handle_message.go
@@ -29,12 +29,19 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncBoardOplogMsg:
 		err = pm.HandleSyncBoardOplog(dataBytes, peer)
 
+	case ForceSyncBoardOplogByMerkleMsg:
+		return pm.HandleForceSyncBoardOplogByMerkle(dataBytes, peer)
+	case ForceSyncBoardOplogByMerkleAckMsg:
+		return pm.HandleForceSyncBoardOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncBoardOplogByOplogAckMsg:
+		return pm.HandleForceSyncBoardOplogByOplogAck(dataBytes, peer)
+	case InvalidSyncBoardOplogMsg:
+		err = pm.HandleSyncBoardOplogInvalid(dataBytes, peer)
+
 	case ForceSyncBoardOplogMsg:
 		err = pm.HandleForceSyncBoardOplog(dataBytes, peer)
 	case ForceSyncBoardOplogAckMsg:
 		err = pm.HandleForceSyncBoardOplogAck(dataBytes, peer)
-	case InvalidSyncBoardOplogMsg:
-		err = pm.HandleSyncBoardOplogInvalidAck(dataBytes, peer)
 
 	case SyncBoardOplogAckMsg:
 		err = pm.HandleSyncBoardOplogAck(dataBytes, peer)

--- a/content/protocol_sync_board_oplog.go
+++ b/content/protocol_sync_board_oplog.go
@@ -34,3 +34,12 @@ func (pm *ProtocolManager) SyncBoardOplog(peer *pkgservice.PttPeer) error {
 func (pm *ProtocolManager) SyncPendingBoardOplog(peer *pkgservice.PttPeer) error {
 	return pm.SyncPendingOplog(peer, pm.SetBoardDB, pm.HandleFailedBoardOplog, SyncPendingBoardOplogMsg)
 }
+
+func (pm *ProtocolManager) ForceSyncBoardMerkle() (bool, error) {
+	err := pm.boardOplogMerkle.TryForceSync(pm)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/content/protocol_update_article.go
+++ b/content/protocol_update_article.go
@@ -56,6 +56,8 @@ func (pm *ProtocolManager) UpdateArticle(articleID *types.PttID, articleBytes []
 		return nil, err
 	}
 
+	log.Debug("UpdateArticle: done", "entity", pm.Entity().IDString())
+
 	return origObj, nil
 }
 

--- a/content/protocol_update_article_logs.go
+++ b/content/protocol_update_article_logs.go
@@ -18,6 +18,7 @@ package content
 
 import (
 	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
 	pkgservice "github.com/ailabstw/go-pttai/service"
 )
 
@@ -26,6 +27,8 @@ func (pm *ProtocolManager) handleUpdateArticleLogs(oplog *pkgservice.BaseOplog, 
 	pm.SetArticleDB(obj)
 
 	opData := &BoardOpUpdateArticle{}
+
+	log.Debug("handleUpdateArticleLogs: to HandleUpdateObjectLog", "entity", pm.Entity().IDString(), "IsSync", oplog.IsSync)
 
 	return pm.HandleUpdateObjectLog(
 		oplog,
@@ -48,6 +51,8 @@ func (pm *ProtocolManager) handlePendingUpdateArticleLogs(oplog *pkgservice.Base
 	pm.SetArticleDB(obj)
 
 	opData := &BoardOpUpdateArticle{}
+
+	log.Debug("handlePendingUpdateArticleLogs: to HandlePendingUpdateObjectLog", "entity", pm.Entity().IDString())
 
 	return pm.HandlePendingUpdateObjectLog(
 		oplog,

--- a/e2e/multi_device3_sync_invalid_article_test.go
+++ b/e2e/multi_device3_sync_invalid_article_test.go
@@ -1,0 +1,779 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package e2e
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ailabstw/go-pttai/common"
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/content"
+	"github.com/ailabstw/go-pttai/crypto"
+	"github.com/ailabstw/go-pttai/log"
+	"github.com/ailabstw/go-pttai/me"
+	pkgservice "github.com/ailabstw/go-pttai/service"
+	"github.com/stretchr/testify/assert"
+	baloo "gopkg.in/h2non/baloo.v3"
+)
+
+func TestMultiDevice3SyncInvalidArticle(t *testing.T) {
+	NNodes = 3
+	isDebug := true
+
+	var bodyString string
+	var marshaledID []byte
+	var marshaledID2 []byte
+	var marshaledID3 []byte
+	var marshaledStr string
+	var offsetSecond int64
+	assert := assert.New(t)
+
+	setupTest(t)
+	defer teardownTest(t)
+
+	t0 := baloo.New("http://127.0.0.1:9450")
+	t1 := baloo.New("http://127.0.0.1:9451")
+	t2 := baloo.New("http://127.0.0.1:9452")
+
+	// 1. get
+	bodyString = `{"id": "testID", "method": "me_get", "params": []}`
+
+	me0_1 := &me.BackendMyInfo{}
+	testCore(t0, bodyString, me0_1, t, isDebug)
+	assert.Equal(types.StatusAlive, me0_1.Status)
+
+	//nodeID0_1 := me0_1.NodeID
+	//pubKey0_1, _ := nodeID0_1.Pubkey()
+	//nodeAddr0_1 := crypto.PubkeyToAddress(*pubKey0_1)
+
+	me1_1 := &me.BackendMyInfo{}
+	testCore(t1, bodyString, me1_1, t, isDebug)
+	assert.Equal(types.StatusAlive, me1_1.Status)
+	nodeID1_1 := me1_1.NodeID
+	pubKey1_1, _ := nodeID1_1.Pubkey()
+	nodeAddr1_1 := crypto.PubkeyToAddress(*pubKey1_1)
+
+	me2_1 := &me.BackendMyInfo{}
+	testCore(t2, bodyString, me2_1, t, isDebug)
+	assert.Equal(types.StatusAlive, me2_1.Status)
+
+	// 3. getRawMe
+	bodyString = `{"id": "testID", "method": "me_getRawMe", "params": [""]}`
+
+	me0_3 := &me.MyInfo{}
+	testCore(t0, bodyString, me0_3, t, isDebug)
+	assert.Equal(types.StatusAlive, me0_3.Status)
+	assert.Equal(me0_1.ID, me0_3.ID)
+	assert.Equal(1, len(me0_3.OwnerIDs))
+	assert.Equal(me0_3.ID, me0_3.OwnerIDs[0])
+	assert.Equal(true, me0_3.IsOwner(me0_3.ID))
+
+	me1_3 := &me.MyInfo{}
+	testCore(t1, bodyString, me1_3, t, isDebug)
+	assert.Equal(types.StatusAlive, me1_3.Status)
+	assert.Equal(me1_1.ID, me1_3.ID)
+	assert.Equal(1, len(me1_3.OwnerIDs))
+	assert.Equal(me1_3.ID, me1_3.OwnerIDs[0])
+	assert.Equal(true, me1_3.IsOwner(me1_3.ID))
+
+	me2_3 := &me.MyInfo{}
+	testCore(t2, bodyString, me2_3, t, isDebug)
+	assert.Equal(types.StatusAlive, me2_3.Status)
+	assert.Equal(me2_1.ID, me2_3.ID)
+	assert.Equal(1, len(me2_3.OwnerIDs))
+	assert.Equal(me2_3.ID, me2_3.OwnerIDs[0])
+	assert.Equal(true, me2_3.IsOwner(me2_3.ID))
+
+	// 4. show-my-key
+	bodyString = `{"id": "testID", "method": "me_showMyKey", "params": []}`
+
+	var myKey0_4 string
+
+	testCore(t0, bodyString, &myKey0_4, t, isDebug)
+	if isDebug {
+		t.Logf("myKey0_4: %v\n", myKey0_4)
+	}
+
+	var myKey2_4 string
+
+	testCore(t2, bodyString, &myKey2_4, t, isDebug)
+	if isDebug {
+		t.Logf("myKey2_4: %v\n", myKey2_4)
+	}
+
+	// 5. show-me-url
+	bodyString = `{"id": "testID", "method": "me_showMeURL", "params": []}`
+
+	dataShowMeURL1_5 := &pkgservice.BackendJoinURL{}
+	testCore(t1, bodyString, dataShowMeURL1_5, t, isDebug)
+	meURL1_5 := dataShowMeURL1_5.URL
+
+	// 6. me_GetMyNodes
+	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`
+	dataGetMyNodes0_6 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetMyNodes0_6, t, isDebug)
+	assert.Equal(1, len(dataGetMyNodes0_6.Result))
+
+	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`
+	dataGetMyNodes1_6 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMyNodes1_6, t, isDebug)
+	assert.Equal(1, len(dataGetMyNodes1_6.Result))
+
+	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`
+	dataGetMyNodes2_6 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetMyNodes2_6, t, isDebug)
+	assert.Equal(1, len(dataGetMyNodes2_6.Result))
+
+	// 6.1 getJoinKeys
+	bodyString = `{"id": "testID", "method": "me_getJoinKeyInfos", "params": [""]}`
+	dataGetJoinKeys0_6_1 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetJoinKeys0_6_1, t, isDebug)
+	assert.Equal(1, len(dataGetJoinKeys0_6_1.Result))
+
+	// 7. join-me
+	log.Debug("7. join-me")
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "me_joinMe", "params": ["%v", "%v", false]}`, meURL1_5, myKey0_4)
+
+	dataJoinMe0_7 := &pkgservice.BackendJoinRequest{}
+	testCore(t0, bodyString, dataJoinMe0_7, t, true)
+
+	assert.Equal(me1_3.ID, dataJoinMe0_7.CreatorID)
+	assert.Equal(me1_1.NodeID, dataJoinMe0_7.NodeID)
+
+	// wait 10
+	t.Logf("wait 10 seconds for hand-shaking")
+	time.Sleep(TimeSleepRestart)
+
+	// 7.1. join-me
+	log.Debug("7.1. join-me")
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "me_joinMe", "params": ["%v", "%v", false]}`, meURL1_5, myKey2_4)
+
+	dataJoinMe2_7 := &pkgservice.BackendJoinRequest{}
+	testCore(t2, bodyString, dataJoinMe2_7, t, true)
+
+	assert.Equal(me1_3.ID, dataJoinMe2_7.CreatorID)
+	assert.Equal(me1_1.NodeID, dataJoinMe2_7.NodeID)
+
+	// wait 10
+	t.Logf("wait 10 seconds for hand-shaking")
+	time.Sleep(TimeSleepRestart)
+
+	// 8. me_GetMyNodes
+	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`
+	dataGetMyNodes0_8 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetMyNodes0_8, t, isDebug)
+	assert.Equal(3, len(dataGetMyNodes0_8.Result))
+	myNode0_8_0 := dataGetMyNodes0_8.Result[0]
+	myNode0_8_1 := dataGetMyNodes0_8.Result[1]
+	myNode0_8_2 := dataGetMyNodes0_8.Result[2]
+
+	assert.Equal(types.StatusAlive, myNode0_8_0.Status)
+	assert.Equal(types.StatusAlive, myNode0_8_1.Status)
+	assert.Equal(types.StatusAlive, myNode0_8_2.Status)
+
+	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`
+	dataGetMyNodes1_8 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMyNodes1_8, t, isDebug)
+	assert.Equal(3, len(dataGetMyNodes1_8.Result))
+	myNode1_8_0 := dataGetMyNodes1_8.Result[0]
+	myNode1_8_1 := dataGetMyNodes1_8.Result[1]
+	myNode1_8_2 := dataGetMyNodes1_8.Result[2]
+
+	assert.Equal(types.StatusAlive, myNode1_8_0.Status)
+	assert.Equal(types.StatusAlive, myNode1_8_1.Status)
+	assert.Equal(types.StatusAlive, myNode1_8_2.Status)
+
+	bodyString = `{"id": "testID", "method": "me_getMyNodes", "params": []}`
+	dataGetMyNodes2_8 := &struct {
+		Result []*me.MyNode `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetMyNodes2_8, t, isDebug)
+	assert.Equal(3, len(dataGetMyNodes2_8.Result))
+	myNode2_8_0 := dataGetMyNodes2_8.Result[0]
+	myNode2_8_1 := dataGetMyNodes2_8.Result[1]
+	myNode2_8_2 := dataGetMyNodes2_8.Result[2]
+
+	assert.Equal(types.StatusAlive, myNode2_8_0.Status)
+	assert.Equal(types.StatusAlive, myNode2_8_1.Status)
+	assert.Equal(types.StatusAlive, myNode2_8_2.Status)
+
+	// 8.1. getRawMe
+	bodyString = `{"id": "testID", "method": "me_getRawMe", "params": [""]}`
+
+	me0_8_1 := &me.MyInfo{}
+	testCore(t0, bodyString, me0_8_1, t, isDebug)
+	assert.Equal(types.StatusAlive, me0_8_1.Status)
+	assert.Equal(1, len(me0_8_1.OwnerIDs))
+	assert.Equal(me1_3.ID, me0_8_1.OwnerIDs[0])
+	assert.Equal(true, me0_8_1.IsOwner(me1_3.ID))
+
+	me1_8_1 := &me.MyInfo{}
+	testCore(t1, bodyString, me1_8_1, t, isDebug)
+	assert.Equal(types.StatusAlive, me1_8_1.Status)
+	assert.Equal(me1_3.ID, me1_8_1.ID)
+	assert.Equal(1, len(me1_8_1.OwnerIDs))
+	assert.Equal(me1_3.ID, me1_8_1.OwnerIDs[0])
+	assert.Equal(true, me1_8_1.IsOwner(me1_3.ID))
+
+	me2_8_1 := &me.MyInfo{}
+	testCore(t2, bodyString, me2_8_1, t, isDebug)
+	assert.Equal(types.StatusAlive, me2_8_1.Status)
+	assert.Equal(1, len(me2_8_1.OwnerIDs))
+	assert.Equal(me1_3.ID, me2_8_1.OwnerIDs[0])
+	assert.Equal(true, me2_8_1.IsOwner(me1_3.ID))
+
+	// 9. MasterOplog
+	bodyString = `{"id": "testID", "method": "me_getMyMasterOplogList", "params": ["", "", 0, 2]}`
+
+	dataMasterOplogs0_9 := &struct {
+		Result []*me.MasterOplog `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataMasterOplogs0_9, t, isDebug)
+	assert.Equal(5, len(dataMasterOplogs0_9.Result))
+	masterOplog0_9 := dataMasterOplogs0_9.Result[0]
+	assert.Equal(me1_3.ID[:common.AddressLength], masterOplog0_9.CreatorID[common.AddressLength:])
+	assert.Equal(me1_3.ID, masterOplog0_9.ObjID)
+	assert.Equal(me.MasterOpTypeAddMaster, masterOplog0_9.Op)
+	assert.Equal(nilPttID, masterOplog0_9.PreLogID)
+	assert.Equal(types.Bool(true), masterOplog0_9.IsSync)
+	assert.Equal(masterOplog0_9.ID, masterOplog0_9.MasterLogID)
+
+	dataMasterOplogs1_9 := &struct {
+		Result []*me.MasterOplog `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataMasterOplogs1_9, t, isDebug)
+	assert.Equal(5, len(dataMasterOplogs1_9.Result))
+	masterOplog1_9 := dataMasterOplogs1_9.Result[0]
+	assert.Equal(me1_3.ID[:common.AddressLength], masterOplog1_9.CreatorID[common.AddressLength:])
+	assert.Equal(me1_3.ID, masterOplog1_9.ObjID)
+	assert.Equal(me.MasterOpTypeAddMaster, masterOplog1_9.Op)
+	assert.Equal(nilPttID, masterOplog1_9.PreLogID)
+	assert.Equal(types.Bool(true), masterOplog1_9.IsSync)
+	assert.Equal(masterOplog1_9.ID, masterOplog1_9.MasterLogID)
+
+	for i, oplog := range dataMasterOplogs0_9.Result {
+		oplog1 := dataMasterOplogs1_9.Result[i]
+		oplog.CreateTS = oplog1.CreateTS
+		oplog.CreatorID = oplog1.CreatorID
+		oplog.CreatorHash = oplog1.CreatorHash
+		oplog.Salt = oplog1.Salt
+		oplog.Sig = oplog1.Sig
+		oplog.Pubkey = oplog1.Pubkey
+		oplog.KeyExtra = oplog1.KeyExtra
+		oplog.UpdateTS = oplog1.UpdateTS
+		oplog.Hash = oplog1.Hash
+		oplog.IsNewer = oplog1.IsNewer
+		oplog.Extra = oplog1.Extra
+	}
+	assert.Equal(dataMasterOplogs0_9, dataMasterOplogs1_9)
+
+	dataMasterOplogs2_9 := &struct {
+		Result []*me.MasterOplog `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataMasterOplogs2_9, t, isDebug)
+	assert.Equal(5, len(dataMasterOplogs2_9.Result))
+	masterOplog2_9 := dataMasterOplogs2_9.Result[0]
+	assert.Equal(me1_3.ID[:common.AddressLength], masterOplog2_9.CreatorID[common.AddressLength:])
+	assert.Equal(me1_3.ID, masterOplog2_9.ObjID)
+	assert.Equal(me.MasterOpTypeAddMaster, masterOplog2_9.Op)
+	assert.Equal(nilPttID, masterOplog2_9.PreLogID)
+	assert.Equal(types.Bool(true), masterOplog2_9.IsSync)
+	assert.Equal(masterOplog2_9.ID, masterOplog2_9.MasterLogID)
+
+	// 9.1. getRawMe
+	marshaledID, _ = me0_3.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "me_getRawMe", "params": ["%v"]}`, string(marshaledID))
+
+	me0_9_1 := &me.MyInfo{}
+	testCore(t0, bodyString, me0_9_1, t, isDebug)
+	assert.Equal(types.StatusMigrated, me0_9_1.Status)
+	assert.Equal(2, len(me0_9_1.OwnerIDs))
+	assert.Equal(true, me0_9_1.IsOwner(me1_3.ID))
+	assert.Equal(true, me0_9_1.IsOwner(me0_3.ID))
+
+	// 9.2. MeOplog
+	bodyString = `{"id": "testID", "method": "me_getMeOplogList", "params": ["", 0, 2]}`
+
+	dataMeOplogs0_9_2 := &struct {
+		Result []*me.MeOplog `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataMeOplogs0_9_2, t, isDebug)
+	assert.Equal(1, len(dataMeOplogs0_9_2.Result))
+	meOplog0_9_2 := dataMeOplogs0_9_2.Result[0]
+	assert.Equal(me1_3.ID, meOplog0_9_2.CreatorID)
+	assert.Equal(me1_3.ID, meOplog0_9_2.ObjID)
+	assert.Equal(me.MeOpTypeCreateMe, meOplog0_9_2.Op)
+	assert.Equal(nilPttID, meOplog0_9_2.PreLogID)
+	assert.Equal(types.Bool(true), meOplog0_9_2.IsSync)
+	assert.Equal(masterOplog1_9.ID, meOplog0_9_2.MasterLogID)
+	assert.Equal(me1_3.LogID, meOplog0_9_2.ID)
+	masterSign0_9_2 := meOplog0_9_2.MasterSigns[0]
+	assert.Equal(nodeAddr1_1[:], masterSign0_9_2.ID[:common.AddressLength])
+	assert.Equal(me1_3.ID[:common.AddressLength], masterSign0_9_2.ID[common.AddressLength:])
+	assert.Equal(me0_8_1.LogID, meOplog0_9_2.ID)
+
+	dataMeOplogs1_9_2 := &struct {
+		Result []*me.MeOplog `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataMeOplogs1_9_2, t, isDebug)
+	assert.Equal(1, len(dataMeOplogs1_9_2.Result))
+	meOplog1_9_2 := dataMeOplogs1_9_2.Result[0]
+	assert.Equal(me1_3.ID, meOplog1_9_2.CreatorID)
+	assert.Equal(me1_3.ID, meOplog1_9_2.ObjID)
+	assert.Equal(me.MeOpTypeCreateMe, meOplog1_9_2.Op)
+	assert.Equal(nilPttID, meOplog1_9_2.PreLogID)
+	assert.Equal(types.Bool(true), meOplog1_9_2.IsSync)
+	assert.Equal(masterOplog1_9.ID, meOplog1_9_2.MasterLogID)
+	assert.Equal(me1_3.LogID, meOplog1_9_2.ID)
+	masterSign1_9_2 := meOplog1_9_2.MasterSigns[0]
+	assert.Equal(nodeAddr1_1[:], masterSign1_9_2.ID[:common.AddressLength])
+	assert.Equal(me1_3.ID[:common.AddressLength], masterSign1_9_2.ID[common.AddressLength:])
+	assert.Equal(meOplog0_9_2, meOplog1_9_2)
+	assert.Equal(me1_8_1.LogID, meOplog1_9_2.ID)
+
+	// 10. get board list
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardList", "params": ["", 0, 2]}`)
+
+	dataBoardList0_10 := &struct {
+		Result []*content.BackendGetBoard `json:"result"`
+	}{}
+
+	testListCore(t0, bodyString, dataBoardList0_10, t, isDebug)
+	assert.Equal(2, len(dataBoardList0_10.Result))
+	board0_10_0 := dataBoardList0_10.Result[0]
+	assert.Equal(me0_3.BoardID, board0_10_0.ID)
+	assert.Equal(types.StatusMigrated, board0_10_0.Status)
+
+	defaultTitle0_10_0 := content.DefaultTitleTW(me0_1.ID, me1_1.ID, "")
+	assert.Equal(defaultTitle0_10_0, board0_10_0.Title)
+
+	board0_10_1 := dataBoardList0_10.Result[1]
+	assert.Equal(me1_3.BoardID, board0_10_1.ID)
+	assert.Equal(types.StatusAlive, board0_10_1.Status)
+
+	defaultTitle0_10_1 := content.DefaultTitleTW(me1_1.ID, me1_1.ID, "")
+	assert.Equal(defaultTitle0_10_1, board0_10_1.Title)
+
+	dataBoardList2_10 := &struct {
+		Result []*content.BackendGetBoard `json:"result"`
+	}{}
+
+	testListCore(t2, bodyString, dataBoardList2_10, t, isDebug)
+	assert.Equal(2, len(dataBoardList2_10.Result))
+	board2_10_0 := dataBoardList2_10.Result[0]
+	assert.Equal(me2_3.BoardID, board2_10_0.ID)
+	assert.Equal(types.StatusMigrated, board2_10_0.Status)
+
+	defaultTitle2_10_0 := content.DefaultTitleTW(me2_1.ID, me1_1.ID, "")
+	assert.Equal(defaultTitle2_10_0, board2_10_0.Title)
+
+	board2_10_1 := dataBoardList2_10.Result[1]
+	assert.Equal(me1_3.BoardID, board2_10_1.ID)
+	assert.Equal(types.StatusAlive, board2_10_1.Status)
+
+	defaultTitle2_10_1 := content.DefaultTitleTW(me1_1.ID, me1_1.ID, "")
+	assert.Equal(defaultTitle2_10_1, board2_10_1.Title)
+
+	// 10.1.
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getArticleList", "params": ["%v", "", 0, 2]}`, string(marshaledID))
+
+	dataGetArticleList0_10_1 := &struct {
+		Result []*content.BackendGetArticle `json:"result"`
+	}{}
+	testCore(t0, bodyString, dataGetArticleList0_10_1, t, isDebug)
+
+	assert.Equal(0, len(dataGetArticleList0_10_1.Result))
+
+	// 35. t1 create article.
+	article, _ := json.Marshal([]string{
+		base64.StdEncoding.EncodeToString([]byte("測試1")),
+		base64.StdEncoding.EncodeToString([]byte("測試2")),
+		base64.StdEncoding.EncodeToString([]byte("測試3")),
+		base64.StdEncoding.EncodeToString([]byte("測試4")),
+		base64.StdEncoding.EncodeToString([]byte("測試5")),
+		base64.StdEncoding.EncodeToString([]byte("測試6")),
+		base64.StdEncoding.EncodeToString([]byte("測試7")),
+		base64.StdEncoding.EncodeToString([]byte("測試8")),
+		base64.StdEncoding.EncodeToString([]byte("測試9")),
+		base64.StdEncoding.EncodeToString([]byte("測試10")),
+		base64.StdEncoding.EncodeToString([]byte("測試11")),
+		base64.StdEncoding.EncodeToString([]byte("測試12")),
+		base64.StdEncoding.EncodeToString([]byte("測試13")),
+		base64.StdEncoding.EncodeToString([]byte("測試14")),
+		base64.StdEncoding.EncodeToString([]byte("測試15")),
+		base64.StdEncoding.EncodeToString([]byte("測試16")),
+		base64.StdEncoding.EncodeToString([]byte("測試17")),
+		base64.StdEncoding.EncodeToString([]byte("測試18")),
+		base64.StdEncoding.EncodeToString([]byte("測試19")),
+		base64.StdEncoding.EncodeToString([]byte("測試20")),
+		base64.StdEncoding.EncodeToString([]byte("測試21")),
+		base64.StdEncoding.EncodeToString([]byte("測試22")),
+	})
+
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+
+	title1_35 := []byte("標題1")
+	marshaledStr = base64.StdEncoding.EncodeToString(title1_35)
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_createArticle", "params": ["%v", "%v", %v, []]}`, string(marshaledID), marshaledStr, string(article))
+	dataCreateArticle1_35 := &content.BackendCreateArticle{}
+	testCore(t1, bodyString, dataCreateArticle1_35, t, isDebug)
+	assert.Equal(board0_10_1.ID, dataCreateArticle1_35.BoardID)
+	assert.Equal(3, dataCreateArticle1_35.NBlock)
+
+	// wait 10 secs
+	time.Sleep(TimeSleepDefault)
+
+	// 36. content-get-article-list
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getArticleList", "params": ["%v", "", 0, 2]}`, string(marshaledID))
+	dataGetArticleList0_36 := &struct {
+		Result []*content.BackendGetArticle `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetArticleList0_36, t, isDebug)
+	assert.Equal(1, len(dataGetArticleList0_36.Result))
+	article0_36 := dataGetArticleList0_36.Result[0]
+	assert.Equal(types.StatusAlive, article0_36.Status)
+
+	dataGetArticleList1_36 := &struct {
+		Result []*content.BackendGetArticle `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetArticleList1_36, t, isDebug)
+	assert.Equal(1, len(dataGetArticleList1_36.Result))
+	article1_36 := dataGetArticleList1_36.Result[0]
+	assert.Equal(types.StatusAlive, article1_36.Status)
+	assert.Equal(article0_36.ID, article1_36.ID)
+
+	dataGetArticleList2_36 := &struct {
+		Result []*content.BackendGetArticle `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetArticleList2_36, t, isDebug)
+	assert.Equal(1, len(dataGetArticleList2_36.Result))
+	article2_36 := dataGetArticleList2_36.Result[0]
+	assert.Equal(types.StatusAlive, article2_36.Status)
+
+	// 37. get-article-block
+	marshaledID2, _ = article0_36.ID.MarshalText()
+	marshaledID3, _ = article0_36.ContentBlockID.MarshalText()
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getArticleBlockList", "params": ["%v", "%v", "%v", 0, 0, 10, 2]}`, string(marshaledID), string(marshaledID2), string(marshaledID3))
+
+	dataGetArticleBlockList0_37 := &struct {
+		Result []*content.ArticleBlock `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetArticleBlockList0_37, t, isDebug)
+	assert.Equal(3, len(dataGetArticleBlockList0_37.Result))
+
+	article0 := [][]byte{
+		[]byte("測試1"),
+	}
+
+	article1 := [][]byte{
+		[]byte("測試2"),
+		[]byte("測試3"),
+		[]byte("測試4"),
+		[]byte("測試5"),
+		[]byte("測試6"),
+		[]byte("測試7"),
+		[]byte("測試8"),
+		[]byte("測試9"),
+		[]byte("測試10"),
+		[]byte("測試11"),
+		[]byte("測試12"),
+		[]byte("測試13"),
+		[]byte("測試14"),
+		[]byte("測試15"),
+		[]byte("測試16"),
+		[]byte("測試17"),
+		[]byte("測試18"),
+		[]byte("測試19"),
+		[]byte("測試20"),
+		[]byte("測試21"),
+	}
+
+	article2 := [][]byte{
+		[]byte("測試22"),
+	}
+
+	assert.Equal(article0, dataGetArticleBlockList0_37.Result[0].Buf)
+	assert.Equal(article1, dataGetArticleBlockList0_37.Result[1].Buf)
+	assert.Equal(article2, dataGetArticleBlockList0_37.Result[2].Buf)
+
+	dataGetArticleBlockList1_37 := &struct {
+		Result []*content.ArticleBlock `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetArticleBlockList1_37, t, isDebug)
+	assert.Equal(3, len(dataGetArticleBlockList1_37.Result))
+
+	assert.Equal(article0, dataGetArticleBlockList1_37.Result[0].Buf)
+	assert.Equal(article1, dataGetArticleBlockList1_37.Result[1].Buf)
+	assert.Equal(article2, dataGetArticleBlockList1_37.Result[2].Buf)
+
+	dataGetArticleBlockList2_37 := &struct {
+		Result []*content.ArticleBlock `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetArticleBlockList2_37, t, isDebug)
+	assert.Equal(3, len(dataGetArticleBlockList2_37.Result))
+
+	assert.Equal(article0, dataGetArticleBlockList2_37.Result[0].Buf)
+	assert.Equal(article1, dataGetArticleBlockList2_37.Result[1].Buf)
+	assert.Equal(article2, dataGetArticleBlockList2_37.Result[2].Buf)
+
+	// 40. merkle-node-list (now)
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardOplogMerkleNodeList", "params": ["%v", 1, "", 0, 2]}`, string(marshaledID))
+
+	dataGetMerkleNodeList0_40_0 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetMerkleNodeList0_40_0, t, isDebug)
+	assert.Equal(2, len(dataGetMerkleNodeList0_40_0.Result))
+
+	dataGetMerkleNodeList1_40_0 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMerkleNodeList1_40_0, t, isDebug)
+	assert.Equal(2, len(dataGetMerkleNodeList1_40_0.Result))
+
+	dataGetMerkleNodeList2_40_0 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetMerkleNodeList2_40_0, t, isDebug)
+	assert.Equal(2, len(dataGetMerkleNodeList2_40_0.Result))
+
+	// 40.1. merkle-node-list (day)
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardOplogMerkleNodeList", "params": ["%v", 2, "", 0, 2]}`, string(marshaledID))
+
+	dataGetMerkleNodeList0_40_1 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetMerkleNodeList0_40_1, t, isDebug)
+	assert.Equal(1, len(dataGetMerkleNodeList0_40_1.Result))
+	merkleNode0_40_1_0 := dataGetMerkleNodeList0_40_1.Result[0]
+	assert.Equal(uint32(1), merkleNode0_40_1_0.NChildren)
+
+	dataGetMerkleNodeList1_40_1 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMerkleNodeList1_40_1, t, isDebug)
+	assert.Equal(1, len(dataGetMerkleNodeList1_40_1.Result))
+	merkleNode1_40_1_0 := dataGetMerkleNodeList1_40_1.Result[0]
+	assert.Equal(uint32(1), merkleNode1_40_1_0.NChildren)
+
+	dataGetMerkleNodeList2_40_1 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetMerkleNodeList2_40_1, t, isDebug)
+	assert.Equal(1, len(dataGetMerkleNodeList2_40_1.Result))
+	merkleNode2_40_1_0 := dataGetMerkleNodeList2_40_1.Result[0]
+	assert.Equal(uint32(1), merkleNode2_40_1_0.NChildren)
+
+	// 41. time-forward
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "ptt_getTimestamp", "params": []}`)
+
+	var sec0_41_0 types.Timestamp
+	testCore(t0, bodyString, &sec0_41_0, t, isDebug)
+
+	// 41.1. time-forward.
+	offsetSecond = 14400
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "ptt_setOffsetSecond", "params": [%v]}`, offsetSecond)
+
+	bool0_41_1 := false
+	testCore(t0, bodyString, &bool0_41_1, t, isDebug)
+
+	bool1_41_1 := false
+	testCore(t1, bodyString, &bool1_41_1, t, isDebug)
+
+	bool2_41_1 := false
+	testCore(t2, bodyString, &bool2_41_1, t, isDebug)
+
+	// 41.2. get offset-second
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "ptt_getTimestamp", "params": []}`)
+
+	var sec0_41_2 types.Timestamp
+	testCore(t0, bodyString, &sec0_41_2, t, isDebug)
+	assert.Equal(sec0_41_0.Ts+offsetSecond, sec0_41_2.Ts)
+
+	// 41.3. t1 create article.
+	article, _ = json.Marshal([]string{
+		base64.StdEncoding.EncodeToString([]byte("測試31")),
+		base64.StdEncoding.EncodeToString([]byte("測試32")),
+		base64.StdEncoding.EncodeToString([]byte("測試33")),
+		base64.StdEncoding.EncodeToString([]byte("測試34")),
+		base64.StdEncoding.EncodeToString([]byte("測試35")),
+		base64.StdEncoding.EncodeToString([]byte("測試36")),
+		base64.StdEncoding.EncodeToString([]byte("測試37")),
+		base64.StdEncoding.EncodeToString([]byte("測試38")),
+		base64.StdEncoding.EncodeToString([]byte("測試39")),
+		base64.StdEncoding.EncodeToString([]byte("測試40")),
+		base64.StdEncoding.EncodeToString([]byte("測試41")),
+		base64.StdEncoding.EncodeToString([]byte("測試42")),
+		base64.StdEncoding.EncodeToString([]byte("測試43")),
+		base64.StdEncoding.EncodeToString([]byte("測試44")),
+		base64.StdEncoding.EncodeToString([]byte("測試45")),
+		base64.StdEncoding.EncodeToString([]byte("測試46")),
+		base64.StdEncoding.EncodeToString([]byte("測試47")),
+		base64.StdEncoding.EncodeToString([]byte("測試48")),
+		base64.StdEncoding.EncodeToString([]byte("測試49")),
+		base64.StdEncoding.EncodeToString([]byte("測試50")),
+		base64.StdEncoding.EncodeToString([]byte("測試51")),
+		base64.StdEncoding.EncodeToString([]byte("測試52")),
+	})
+
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+
+	title1_41_3 := []byte("標題2")
+	marshaledStr = base64.StdEncoding.EncodeToString(title1_41_3)
+
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_createArticle", "params": ["%v", "%v", %v, []]}`, string(marshaledID), marshaledStr, string(article))
+	dataCreateArticle1_41_3 := &content.BackendCreateArticle{}
+	testCore(t1, bodyString, dataCreateArticle1_41_3, t, isDebug)
+	assert.Equal(board0_10_1.ID, dataCreateArticle1_41_3.BoardID)
+	assert.Equal(3, dataCreateArticle1_41_3.NBlock)
+
+	// wait 10 secs
+	time.Sleep(TimeSleepDefault)
+
+	// 42.0 get merkle
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	t.Logf("42.0 get merkle: marshaledID: %v", marshaledID)
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardOplogMerkle", "params": ["%v"]}`, string(marshaledID))
+
+	merkle0_42_0 := &pkgservice.BackendMerkle{}
+	testCore(t0, bodyString, merkle0_42_0, t, isDebug)
+
+	merkle1_42_0 := &pkgservice.BackendMerkle{}
+	testCore(t1, bodyString, merkle1_42_0, t, isDebug)
+
+	merkle2_42_0 := &pkgservice.BackendMerkle{}
+	testCore(t2, bodyString, merkle2_42_0, t, isDebug)
+
+	// 42. sync.
+	t.Logf("42. force sync")
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_forceSync", "params": ["%v"]}`, string(marshaledID))
+
+	bool0_42 := false
+	testCore(t0, bodyString, &bool0_42, t, isDebug)
+
+	time.Sleep(5 * time.Second)
+
+	bool1_42 := false
+	testCore(t1, bodyString, &bool1_42, t, isDebug)
+
+	time.Sleep(5 * time.Second)
+
+	bool2_42 := false
+	testCore(t2, bodyString, &bool2_42, t, isDebug)
+
+	time.Sleep(5 * time.Second)
+
+	// 43. shutdown t0.
+	bodyString = `{"id": "testID", "method": "ptt_shutdown", "params": []}`
+
+	resultString := `{"jsonrpc":"2.0","id":"testID","result":true}`
+	testBodyEqualCore(t0, bodyString, resultString, t)
+
+	time.Sleep(5 * time.Second)
+
+	// 44. time-forward.
+	offsetSecond = 28800
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "ptt_setOffsetSecond", "params": [%v]}`, offsetSecond)
+
+	bool1_44_0 := false
+	testCore(t1, bodyString, &bool1_44_0, t, isDebug)
+
+	bool2_44_0 := false
+	testCore(t2, bodyString, &bool2_44_0, t, isDebug)
+
+	// 45. start t0
+	startNode(t, 0, offsetSecond, false)
+
+	time.Sleep(TimeSleepRestart)
+
+	// 45.1. sync.
+	t.Logf("42. force sync")
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_forceSync", "params": ["%v"]}`, string(marshaledID))
+
+	bool1_45_1 := false
+	testCore(t1, bodyString, &bool1_45_1, t, isDebug)
+	assert.Equal(true, bool1_45_1)
+
+	time.Sleep(TimeSleepRestart)
+
+	bool2_45_1 := false
+	testCore(t2, bodyString, &bool2_45_1, t, isDebug)
+	assert.Equal(true, bool2_45_1)
+
+	time.Sleep(TimeSleepRestart)
+
+	// 46. merkle-node-list (day)
+	marshaledID, _ = board0_10_1.ID.MarshalText()
+	bodyString = fmt.Sprintf(`{"id": "testID", "method": "content_getBoardOplogMerkleNodeList", "params": ["%v", 2, "", 0, 2]}`, string(marshaledID))
+
+	dataGetMerkleNodeList0_46_1 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t0, bodyString, dataGetMerkleNodeList0_46_1, t, isDebug)
+	assert.Equal(2, len(dataGetMerkleNodeList0_46_1.Result))
+	merkleNode0_46_1_0 := dataGetMerkleNodeList0_46_1.Result[0]
+	merkleNode0_46_1_1 := dataGetMerkleNodeList0_46_1.Result[1]
+	assert.Equal(uint32(2), merkleNode0_46_1_0.NChildren)
+	assert.Equal(uint32(1), merkleNode0_46_1_1.NChildren)
+
+	dataGetMerkleNodeList1_46_1 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t1, bodyString, dataGetMerkleNodeList1_46_1, t, isDebug)
+	assert.Equal(2, len(dataGetMerkleNodeList1_46_1.Result))
+	merkleNode1_46_1_0 := dataGetMerkleNodeList1_46_1.Result[0]
+	merkleNode1_46_1_1 := dataGetMerkleNodeList1_46_1.Result[1]
+	assert.Equal(uint32(2), merkleNode1_46_1_0.NChildren)
+	assert.Equal(uint32(1), merkleNode1_46_1_1.NChildren)
+
+	dataGetMerkleNodeList2_46_1 := &struct {
+		Result []*pkgservice.BackendMerkleNode `json:"result"`
+	}{}
+	testListCore(t2, bodyString, dataGetMerkleNodeList2_46_1, t, isDebug)
+	assert.Equal(2, len(dataGetMerkleNodeList2_46_1.Result))
+	merkleNode2_46_1_0 := dataGetMerkleNodeList2_46_1.Result[0]
+	merkleNode2_46_1_1 := dataGetMerkleNodeList2_46_1.Result[1]
+	assert.Equal(uint32(2), merkleNode2_46_1_0.NChildren)
+	assert.Equal(uint32(1), merkleNode2_46_1_1.NChildren)
+}

--- a/friend/api.go
+++ b/friend/api.go
@@ -128,6 +128,10 @@ func (api *PrivateAPI) GetFriendOplogMerkleNodeList(entityID string, level uint8
 	return api.b.GetFriendOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncFriendMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncFriendMerkle([]byte(entityID))
+}
+
 /**********
  * MasterOplog
  **********/
@@ -148,6 +152,10 @@ func (api *PrivateAPI) GetMasterOplogMerkleNodeList(entityID string, level uint8
 	return api.b.GetMasterOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncMasterMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMasterMerkle([]byte(entityID))
+}
+
 /**********
  * MemberOplog
  **********/
@@ -166,6 +174,10 @@ func (api *PrivateAPI) GetPendingMemberOplogInternalList(entityID string, logID 
 
 func (api *PrivateAPI) GetMemberOplogMerkleNodeList(entityID string, level uint8, startKey []byte, limit int, listOrder pttdb.ListOrder) ([]*pkgservice.BackendMerkleNode, error) {
 	return api.b.GetMemberOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
+}
+
+func (api *PrivateAPI) ForceSyncMemberMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMemberMerkle([]byte(entityID))
 }
 
 /**********

--- a/friend/backend_core.go
+++ b/friend/backend_core.go
@@ -205,6 +205,16 @@ func (b *Backend) GetFriendOplogMerkleNodeList(entityIDBytes []byte, level pkgse
 	return results, nil
 }
 
+func (b *Backend) ForceSyncFriendMerkle(entityIDBytes []byte) (bool, error) {
+	thePM, err := b.EntityIDToPM(entityIDBytes)
+	if err != nil {
+		return false, err
+	}
+	pm := thePM.(*ProtocolManager)
+
+	return pm.ForceSyncFriendMerkle()
+}
+
 func (b *Backend) CreateMessage(entityIDBytes []byte, message [][]byte, mediaIDStrs []string) (*BackendCreateMessage, error) {
 
 	thePM, err := b.EntityIDToPM(entityIDBytes)

--- a/friend/friend.go
+++ b/friend/friend.go
@@ -142,7 +142,7 @@ func (f *Friend) Init(ptt pkgservice.Ptt, service pkgservice.Service, spm pkgser
 }
 
 func (f *Friend) InitPM(ptt pkgservice.Ptt, service pkgservice.Service) error {
-	pm, err := NewProtocolManager(f, ptt)
+	pm, err := NewProtocolManager(f, ptt, service)
 	if err != nil {
 		return err
 	}

--- a/friend/globals.go
+++ b/friend/globals.go
@@ -71,12 +71,17 @@ const (
 	AddPendingFriendOplogsMsg
 
 	SyncFriendOplogMsg
-	ForceSyncFriendOplogMsg
-	ForceSyncFriendOplogAckMsg
-	InvalidSyncFriendOplogMsg
 	SyncFriendOplogAckMsg
 	SyncFriendOplogNewOplogsMsg
 	SyncFriendOplogNewOplogsAckMsg
+
+	InvalidSyncFriendOplogMsg
+
+	ForceSyncFriendOplogMsg
+	ForceSyncFriendOplogAckMsg
+	ForceSyncFriendOplogByMerkleMsg
+	ForceSyncFriendOplogByMerkleAckMsg
+	ForceSyncFriendOplogByOplogAckMsg
 
 	SyncPendingFriendOplogMsg
 	SyncPendingFriendOplogAckMsg

--- a/friend/protocol_handle_friend_oplogs.go
+++ b/friend/protocol_handle_friend_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncFriendOplog(dataBytes []byte, peer *pkgserv
 
 		pm.friendOplogMerkle,
 
-		ForceSyncFriendOplogMsg,
-		ForceSyncFriendOplogAckMsg,
+		ForceSyncFriendOplogByMerkleMsg,
+		ForceSyncFriendOplogByMerkleAckMsg,
 		InvalidSyncFriendOplogMsg,
 		SyncFriendOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncFriendOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncFriendOplogByMerkleAckMsg,
+		ForceSyncFriendOplogByOplogAckMsg,
+
+		pm.SetFriendDB,
+		pm.SetNewestFriendOplog,
+
+		pm.friendOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncFriendOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncFriendOplogByMerkleMsg,
+
+		pm.friendOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncFriendOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleFriendOplogs,
+
+		pm.friendOplogMerkle,
 	)
 }
 
@@ -86,9 +123,9 @@ func (pm *ProtocolManager) HandleForceSyncFriendOplogAck(dataBytes []byte, peer 
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncFriendOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncFriendOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 

--- a/friend/protocol_manager.go
+++ b/friend/protocol_manager.go
@@ -34,13 +34,17 @@ type ProtocolManager struct {
 	dbMessageIdxPrefix []byte
 }
 
-func NewProtocolManager(f *Friend, ptt pkgservice.Ptt) (*ProtocolManager, error) {
+func NewProtocolManager(f *Friend, ptt pkgservice.Ptt, svc pkgservice.Service) (*ProtocolManager, error) {
 	dbFriendLock, err := types.NewLockMap(pkgservice.SleepTimeLock)
 	if err != nil {
 		return nil, err
 	}
 
-	friendOplogMerkle, err := pkgservice.NewMerkle(DBFriendOplogPrefix, DBFriendMerkleOplogPrefix, f.ID, dbFriend, "friend")
+	entityID := f.ID
+	entityIDBytes, _ := entityID.MarshalText()
+	entityIDStr := string(entityIDBytes)
+
+	friendOplogMerkle, err := pkgservice.NewMerkle(DBFriendOplogPrefix, DBFriendMerkleOplogPrefix, f.ID, dbFriend, "("+entityIDStr+"/"+svc.Name()+":friend)")
 	if err != nil {
 		return nil, err
 	}
@@ -85,6 +89,7 @@ func NewProtocolManager(f *Friend, ptt pkgservice.Ptt) (*ProtocolManager, error)
 		pm.postdeleteFriend, // postdelete
 
 		f, // entity
+		svc,
 
 		dbFriend, // db
 	)
@@ -94,7 +99,6 @@ func NewProtocolManager(f *Friend, ptt pkgservice.Ptt) (*ProtocolManager, error)
 	pm.BaseProtocolManager = b
 
 	// message
-	entityID := f.ID
 	pm.dbMessagePrefix = append(DBMessagePrefix, entityID[:]...)
 	pm.dbMessageIdxPrefix = append(DBMessageIdxPrefix, entityID[:]...)
 

--- a/friend/protocol_manager_utils_handle_message.go
+++ b/friend/protocol_manager_utils_handle_message.go
@@ -48,12 +48,19 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncFriendOplogMsg:
 		err = pm.HandleSyncFriendOplog(dataBytes, peer)
 
+	case ForceSyncFriendOplogByMerkleMsg:
+		return pm.HandleForceSyncFriendOplogByMerkle(dataBytes, peer)
+	case ForceSyncFriendOplogByMerkleAckMsg:
+		return pm.HandleForceSyncFriendOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncFriendOplogByOplogAckMsg:
+		return pm.HandleForceSyncFriendOplogByOplogAck(dataBytes, peer)
+	case InvalidSyncFriendOplogMsg:
+		err = pm.HandleSyncFriendOplogInvalid(dataBytes, peer)
+
 	case ForceSyncFriendOplogMsg:
 		err = pm.HandleForceSyncFriendOplog(dataBytes, peer)
 	case ForceSyncFriendOplogAckMsg:
 		err = pm.HandleForceSyncFriendOplogAck(dataBytes, peer)
-	case InvalidSyncFriendOplogMsg:
-		err = pm.HandleSyncFriendOplogInvalidAck(dataBytes, peer)
 
 	case SyncFriendOplogAckMsg:
 		err = pm.HandleSyncFriendOplogAck(dataBytes, peer)

--- a/friend/protocol_sync_friend_oplog.go
+++ b/friend/protocol_sync_friend_oplog.go
@@ -34,3 +34,12 @@ func (pm *ProtocolManager) SyncFriendOplog(peer *pkgservice.PttPeer) error {
 func (pm *ProtocolManager) SyncPendingFriendOplog(peer *pkgservice.PttPeer) error {
 	return pm.SyncPendingOplog(peer, pm.SetFriendDB, pm.HandleFailedFriendOplog, SyncPendingFriendOplogMsg)
 }
+
+func (pm *ProtocolManager) ForceSyncFriendMerkle() (bool, error) {
+	err := pm.friendOplogMerkle.TryForceSync(pm)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/me/api.go
+++ b/me/api.go
@@ -372,6 +372,10 @@ func (api *PrivateAPI) GetMeOplogMerkleNodeList(entityID string, level uint8, st
 	return api.b.GetMeOplogMerkleNodeList([]byte(entityID), pkgservice.MerkleTreeLevel(level), startKey, limit, listOrder)
 }
 
+func (api *PrivateAPI) ForceSyncMeMerkle(entityID string) (bool, error) {
+	return api.b.ForceSyncMeMerkle([]byte(entityID))
+}
+
 /**********
  * MasterOplog
  **********/

--- a/me/backend_core.go
+++ b/me/backend_core.go
@@ -609,6 +609,16 @@ func (b *Backend) GetMeOplogMerkleNodeList(entityIDBytes []byte, level pkgservic
 	return results, nil
 }
 
+func (b *Backend) ForceSyncMeMerkle(entityIDBytes []byte) (bool, error) {
+	thePM, err := b.EntityIDToPM(entityIDBytes)
+	if err != nil {
+		return false, err
+	}
+	pm := thePM.(*ProtocolManager)
+
+	return pm.ForceSyncMeMerkle()
+}
+
 /**********
  * MasterOplog
  **********/

--- a/me/globals.go
+++ b/me/globals.go
@@ -53,12 +53,17 @@ const (
 	AddPendingMeOplogsMsg
 
 	SyncMeOplogMsg // 47
-	ForceSyncMeOplogMsg
-	ForceSyncMeOplogAckMsg
-	InvalidSyncMeOplogMsg
 	SyncMeOplogAckMsg
 	SyncMeOplogNewOplogsMsg
 	SyncMeOplogNewOplogsAckMsg
+
+	InvalidSyncMeOplogMsg
+
+	ForceSyncMeOplogMsg
+	ForceSyncMeOplogAckMsg
+	ForceSyncMeOplogByMerkleMsg
+	ForceSyncMeOplogByMerkleAckMsg
+	ForceSyncMeOplogByOplogAckMsg
 
 	SyncPendingMeOplogMsg
 	SyncPendingMeOplogAckMsg

--- a/me/my_info.go
+++ b/me/my_info.go
@@ -190,7 +190,7 @@ func (m *MyInfo) loadMyKey() (*ecdsa.PrivateKey, error) {
 }
 
 func (m *MyInfo) InitPM(ptt pkgservice.MyPtt, service pkgservice.Service) error {
-	pm, err := NewProtocolManager(m, ptt)
+	pm, err := NewProtocolManager(m, ptt, service)
 	if err != nil {
 		log.Error("InitPM: unable to NewProtocolManager", "e", err)
 		return err

--- a/me/protocol_handle_me_oplogs.go
+++ b/me/protocol_handle_me_oplogs.go
@@ -49,10 +49,47 @@ func (pm *ProtocolManager) HandleSyncMeOplog(dataBytes []byte, peer *pkgservice.
 
 		pm.meOplogMerkle,
 
-		ForceSyncMeOplogMsg,
-		ForceSyncMeOplogAckMsg,
+		ForceSyncMeOplogByMerkleMsg,
+		ForceSyncMeOplogByMerkleAckMsg,
 		InvalidSyncMeOplogMsg,
 		SyncMeOplogAckMsg,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncMeOplogByMerkle(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncMeOplogByMerkleAckMsg,
+		ForceSyncMeOplogByOplogAckMsg,
+
+		pm.SetMeDB,
+		pm.SetNewestMeOplog,
+
+		pm.meOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncMeOplogByMerkleAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncMeOplogByMerkleMsg,
+
+		pm.meOplogMerkle,
+	)
+}
+
+func (pm *ProtocolManager) HandleForceSyncMeOplogByOplogAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleMeOplogs,
+
+		pm.meOplogMerkle,
 	)
 }
 
@@ -86,9 +123,9 @@ func (pm *ProtocolManager) HandleForceSyncMeOplogAck(dataBytes []byte, peer *pkg
 	)
 }
 
-func (pm *ProtocolManager) HandleSyncMeOplogInvalidAck(dataBytes []byte, peer *pkgservice.PttPeer) error {
+func (pm *ProtocolManager) HandleSyncMeOplogInvalid(dataBytes []byte, peer *pkgservice.PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 

--- a/me/protocol_manager.go
+++ b/me/protocol_manager.go
@@ -95,7 +95,7 @@ type ProtocolManager struct {
 	lockRaft sync.Mutex
 }
 
-func NewProtocolManager(myInfo *MyInfo, ptt pkgservice.MyPtt) (*ProtocolManager, error) {
+func NewProtocolManager(myInfo *MyInfo, ptt pkgservice.MyPtt, svc pkgservice.Service) (*ProtocolManager, error) {
 
 	dbMeLock, err := types.NewLockMap(SleepTimeMeLock)
 	if err != nil {
@@ -108,7 +108,10 @@ func NewProtocolManager(myInfo *MyInfo, ptt pkgservice.MyPtt) (*ProtocolManager,
 	}
 
 	myID := myInfo.ID
-	meOplogMerkle, err := pkgservice.NewMerkle(DBMeOplogPrefix, DBMeMerkleOplogPrefix, myID, dbMe, "me")
+	entityIDBytes, _ := myID.MarshalText()
+	entityIDStr := string(entityIDBytes)
+
+	meOplogMerkle, err := pkgservice.NewMerkle(DBMeOplogPrefix, DBMeMerkleOplogPrefix, myID, dbMe, "("+entityIDStr+"/"+svc.Name()+":me)")
 	if err != nil {
 		return nil, err
 	}
@@ -178,6 +181,7 @@ func NewProtocolManager(myInfo *MyInfo, ptt pkgservice.MyPtt) (*ProtocolManager,
 		nil, // postdelete
 
 		myInfo, // entity
+		svc,
 
 		dbMe, // db
 	)

--- a/me/protocol_manager_utils_handle_message.go
+++ b/me/protocol_manager_utils_handle_message.go
@@ -56,12 +56,19 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case SyncMeOplogMsg:
 		err = pm.HandleSyncMeOplog(dataBytes, peer)
 
+	case ForceSyncMeOplogByMerkleMsg:
+		return pm.HandleForceSyncMeOplogByMerkle(dataBytes, peer)
+	case ForceSyncMeOplogByMerkleAckMsg:
+		return pm.HandleForceSyncMeOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncMeOplogByOplogAckMsg:
+		return pm.HandleForceSyncMeOplogByOplogAck(dataBytes, peer)
+	case InvalidSyncMeOplogMsg:
+		err = pm.HandleSyncMeOplogInvalid(dataBytes, peer)
+
 	case ForceSyncMeOplogMsg:
 		err = pm.HandleForceSyncMeOplog(dataBytes, peer)
 	case ForceSyncMeOplogAckMsg:
 		err = pm.HandleForceSyncMeOplogAck(dataBytes, peer)
-	case InvalidSyncMeOplogMsg:
-		err = pm.HandleSyncMeOplogInvalidAck(dataBytes, peer)
 
 	case SyncMeOplogAckMsg:
 		err = pm.HandleSyncMeOplogAck(dataBytes, peer)
@@ -79,7 +86,6 @@ func (pm *ProtocolManager) HandleMessage(op pkgservice.OpType, dataBytes []byte,
 	case AddMeOplogsMsg:
 		err = pm.HandleAddMeOplogs(dataBytes, peer)
 	case AddPendingMeOplogMsg:
-		log.Debug("HandleMessage: to AddPendingMeOplogMsg")
 		err = pm.HandleAddPendingMeOplog(dataBytes, peer)
 	case AddPendingMeOplogsMsg:
 		err = pm.HandleAddPendingMeOplogs(dataBytes, peer)

--- a/me/protocol_sync_me_oplog.go
+++ b/me/protocol_sync_me_oplog.go
@@ -21,3 +21,12 @@ import pkgservice "github.com/ailabstw/go-pttai/service"
 func (pm *ProtocolManager) SyncPendingMeOplog(peer *pkgservice.PttPeer) error {
 	return pm.SyncPendingOplog(peer, pm.SetMeDB, pm.HandleFailedMeOplog, SyncPendingMeOplogMsg)
 }
+
+func (pm *ProtocolManager) ForceSyncMeMerkle() (bool, error) {
+	err := pm.meOplogMerkle.TryForceSync(pm)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/service/errors.go
+++ b/service/errors.go
@@ -93,6 +93,8 @@ var (
 	ErrNotAlive = errors.New("not alive")
 
 	ErrInvalidFunc = errors.New("invalid function")
+
+	ErrInvalidMerkle = errors.New("invalid merkle")
 )
 
 func ErrResp(code error, format string, v ...interface{}) error {

--- a/service/globals.go
+++ b/service/globals.go
@@ -46,13 +46,13 @@ var (
 
 // protocol
 const (
-	_ uint = iota + 1
-	Ptt2
+	_ uint = iota + 2
+	Ptt3
 )
 
 var (
-	ProtocolVersions = [1]uint{Ptt2}
-	ProtocolName     = "ptt2"
+	ProtocolVersions = [1]uint{Ptt3}
+	ProtocolName     = "ptt3"
 	ProtocolLengths  = [1]uint64{uint64(NCodeType)}
 )
 
@@ -98,10 +98,13 @@ const (
 	AddPendingOpKeyOplogsMsg
 
 	SyncOpKeyOplogMsg
+	SyncOpKeyOplogAckMsg
+
+	InvalidSyncOpKeyOplogMsg
+
 	ForceSyncOpKeyOplogMsg
 	ForceSyncOpKeyOplogAckMsg
-	InvalidSyncOpKeyOplogMsg
-	SyncOpKeyOplogAckMsg
+
 	SyncPendingOpKeyOplogMsg
 	SyncPendingOpKeyOplogAckMsg
 
@@ -116,12 +119,17 @@ const (
 	AddPendingMasterOplogsMsg
 
 	SyncMasterOplogMsg
-	ForceSyncMasterOplogMsg
-	ForceSyncMasterOplogAckMsg
-	InvalidSyncMasterOplogMsg
 	SyncMasterOplogAckMsg
 	SyncMasterOplogNewOplogsMsg
 	SyncMasterOplogNewOplogsAckMsg
+
+	InvalidSyncMasterOplogMsg
+
+	ForceSyncMasterOplogMsg
+	ForceSyncMasterOplogAckMsg
+	ForceSyncMasterOplogByMerkleMsg
+	ForceSyncMasterOplogByMerkleAckMsg
+	ForceSyncMasterOplogByOplogAckMsg
 
 	SyncPendingMasterOplogMsg
 	SyncPendingMasterOplogAckMsg
@@ -134,12 +142,17 @@ const (
 	AddPendingMemberOplogsMsg
 
 	SyncMemberOplogMsg
-	ForceSyncMemberOplogMsg
-	ForceSyncMemberOplogAckMsg
-	InvalidSyncMemberOplogMsg
 	SyncMemberOplogAckMsg
 	SyncMemberOplogNewOplogsMsg
 	SyncMemberOplogNewOplogsAckMsg
+
+	InvalidSyncMemberOplogMsg
+
+	ForceSyncMemberOplogMsg
+	ForceSyncMemberOplogAckMsg
+	ForceSyncMemberOplogByMerkleMsg
+	ForceSyncMemberOplogByMerkleAckMsg
+	ForceSyncMemberOplogByOplogAckMsg
 
 	SyncPendingMemberOplogMsg
 	SyncPendingMemberOplogAckMsg
@@ -272,6 +285,9 @@ var (
 	NMerkleTreeMagicAlloc   = 50
 	MerkleTreeOffsetAddr    = SizeMerkleTreeLevel
 	MerkleTreeOffsetTS      = MerkleTreeOffsetAddr + common.AddressLength
+
+	MerkleTreeKeyOffsetLevel    = pttdb.SizeDBKeyPrefix + types.SizePttID
+	MerkleTreeKeyOffsetUpdateTS = MerkleTreeKeyOffsetLevel + SizeMerkleTreeLevel
 
 	DBMerkleGenerateTimePrefix = []byte(".mtgt")
 	DBMerkleSyncTimePrefix     = []byte(".mtst")

--- a/service/merkle_node.go
+++ b/service/merkle_node.go
@@ -17,7 +17,6 @@
 package service
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -101,114 +100,44 @@ func (m *MerkleNode) UnmarshalJSON(b []byte) error {
 	return m.Unmarshal(d)
 }
 
-/*
-Return: myNewKeys: new keys from from their nodes, theirNewKeys: new keys from my nodes
-*/
-func MergeMerkleNodeKeys(myNodes []*MerkleNode, theirNodes []*MerkleNode) ([][]byte, [][]byte, error) {
-	// XXX TODO: refactor. Currently the 4 conditions are enumerated.
-	lenMyNodes := len(myNodes)
-	lenTheirNodes := len(theirNodes)
-
-	/*
-		for i, myNode := range myNodes {
-			log.Debug("MergeMerkleNodeKeys: to for-loop", "idx", fmt.Sprintf("(%d/%d)", i, lenMyNodes), "myNode", myNode)
-		}
-
-		for i, theirNode := range theirNodes {
-			log.Debug("MergeMerkleNodeKeys: to for-loop", "idx", fmt.Sprintf("(%d/%d)", i, lenTheirNodes), "theirNode", theirNode)
-		}
-	*/
-
-	myNewKeys := make([][]byte, 0, lenTheirNodes)
-	theirNewKeys := make([][]byte, 0, lenMyNodes)
-
-	if lenMyNodes == 0 && lenTheirNodes == 0 {
-		return myNewKeys, theirNewKeys, nil
+func (m *MerkleNode) ConstructUpdateTSAndLevelByKey(key []byte) error {
+	level := MerkleTreeLevel(key[MerkleTreeKeyOffsetLevel])
+	updateTS, err := types.UnmarshalTimestamp(key[MerkleTreeKeyOffsetUpdateTS:])
+	if err != nil {
+		return err
 	}
 
-	var myKey []byte = nil
-	var theirKey []byte = nil
-	if lenTheirNodes == 0 {
-		for pMyNodes, myIdx := myNodes, 0; myIdx < lenMyNodes; pMyNodes, myIdx = pMyNodes[1:], myIdx+1 {
-			myKey = pMyNodes[0].Key
-			theirNewKeys = append(theirNewKeys, myKey)
-		}
-		return myNewKeys, theirNewKeys, nil
+	m.Level = level
+	m.UpdateTS = updateTS
+
+	return nil
+}
+
+func (m *MerkleNode) ToKey(merkle *Merkle) []byte {
+	if m.Level == MerkleTreeLevelNow {
+		return m.Key
 	}
 
-	if lenMyNodes == 0 {
-		for pTheirNodes, theirIdx := theirNodes, 0; theirIdx < lenTheirNodes; pTheirNodes, theirIdx = pTheirNodes[1:], theirIdx+1 {
-			theirKey = pTheirNodes[0].Key
-			myNewKeys = append(myNewKeys, theirKey)
-		}
-		return myNewKeys, theirNewKeys, nil
+	ts := m.UpdateTSToTS()
+
+	key, _ := merkle.MarshalKey(m.Level, ts)
+	return key
+}
+
+func (m *MerkleNode) UpdateTSToTS() types.Timestamp {
+	var ts types.Timestamp
+	switch m.Level {
+	case MerkleTreeLevelNow:
+		ts = m.UpdateTS
+	case MerkleTreeLevelHR:
+		ts, _ = m.UpdateTS.ToHRTimestamp()
+	case MerkleTreeLevelDay:
+		ts, _ = m.UpdateTS.ToDayTimestamp()
+	case MerkleTreeLevelMonth:
+		ts, _ = m.UpdateTS.ToMonthTimestamp()
+	case MerkleTreeLevelYear:
+		ts, _ = m.UpdateTS.ToYearTimestamp()
 	}
 
-	pMyNodes := myNodes
-	myIdx := 0
-	myKey = pMyNodes[0].Key
-
-	pTheirNodes := theirNodes
-	theirIdx := 0
-	theirKey = pTheirNodes[0].Key
-
-	for myIdx < lenMyNodes && theirIdx < lenTheirNodes {
-		cmp := bytes.Compare(myKey, theirKey)
-		//log.Debug("MergeMerkleNodeKeys: after cmp", "idx", fmt.Sprintf("(%d/%d/%d/%d)", myIdx, lenMyNodes, theirIdx, lenTheirNodes), "myKey", myKey, "theirKey", theirKey, "cmp", cmp)
-		if cmp < 0 { // myKey < theirKey
-			theirNewKeys = append(theirNewKeys, myKey)
-			myIdx++
-			if myIdx == lenMyNodes {
-				break
-			}
-			pMyNodes = pMyNodes[1:]
-			myKey = pMyNodes[0].Key
-		} else if cmp > 0 { // myKey > theirKey
-			myNewKeys = append(myNewKeys, theirKey)
-			theirIdx++
-			if theirIdx == lenTheirNodes {
-				break
-			}
-			pTheirNodes = pTheirNodes[1:]
-			theirKey = pTheirNodes[0].Key
-		} else { // myKey == theirKey
-			myIdx++
-			if myIdx < lenMyNodes {
-				pMyNodes = pMyNodes[1:]
-				myKey = pMyNodes[0].Key
-			}
-
-			theirIdx++
-			if theirIdx < lenTheirNodes {
-				pTheirNodes = pTheirNodes[1:]
-				theirKey = pTheirNodes[0].Key
-			}
-		}
-	}
-
-	//log.Debug("MergeMerkleNodeKeys: after for-loop", "myIdx", myIdx, "lenMyNodes", lenMyNodes, "theirNewKeys", theirNewKeys, "theirIdx", theirIdx, "lenTheirNodes", lenTheirNodes, "myNewKeys", myNewKeys)
-
-	for myIdx < lenMyNodes {
-		theirNewKeys = append(theirNewKeys, myKey)
-		myIdx++
-		if myIdx == lenMyNodes {
-			break
-		}
-		pMyNodes = pMyNodes[1:]
-		myKey = pMyNodes[0].Key
-	}
-
-	for theirIdx < lenTheirNodes {
-		myNewKeys = append(myNewKeys, theirKey)
-		theirIdx++
-		if theirIdx == lenTheirNodes {
-			break
-		}
-		pTheirNodes = pTheirNodes[1:]
-		theirKey = pTheirNodes[0].Key
-	}
-
-	//log.Debug("MergeMerkleNodeKeys: after for-loop", "myIdx", myIdx, "lenMyNodes", lenMyNodes, "theirNewKeys", theirNewKeys, "theirIdx", theirIdx, "lenTheirNodes", lenTheirNodes, "myNewKeys", myNewKeys)
-
-	return myNewKeys, theirNewKeys, nil
+	return ts
 }

--- a/service/merkle_utils.go
+++ b/service/merkle_utils.go
@@ -1,0 +1,327 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+func ValidateMerkleTree(
+	myNodes []*MerkleNode,
+	theirNodes []*MerkleNode,
+	ts types.Timestamp,
+
+	pm ProtocolManager,
+	merkle *Merkle,
+
+) (types.Timestamp, bool) {
+	myNodes = validateMerkleTreeTrimNodes(myNodes, ts, pm, merkle)
+	theirNodes = validateMerkleTreeTrimNodes(theirNodes, ts, pm, merkle)
+
+	lenMyNodes := len(myNodes)
+	lenTheirNodes := len(theirNodes)
+
+	var diffTS types.Timestamp
+
+	i := 0
+	for pMyNode, pTheirNode := myNodes, theirNodes; i < lenMyNodes && i < lenTheirNodes; i, pMyNode, pTheirNode = i+1, pMyNode[1:], pTheirNode[1:] {
+		if !reflect.DeepEqual(pMyNode[0].Addr, pTheirNode[0].Addr) {
+			log.Error("ValidateMerkleTree: invalid", "i", i, "len", lenMyNodes, "myNode", pMyNode[0], "theirNode", pTheirNode[0], "name", merkle.Name)
+
+			diffTS = pMyNode[0].UpdateTS
+			if pTheirNode[0].UpdateTS.IsLess(ts) {
+				diffTS = pTheirNode[0].UpdateTS
+			}
+			return diffTS, false
+		}
+	}
+
+	if i < lenMyNodes {
+		return myNodes[i].UpdateTS, false
+	}
+
+	if i < lenTheirNodes {
+		return theirNodes[i].UpdateTS, false
+	}
+
+	return types.ZeroTimestamp, true
+}
+
+func validateMerkleTreeTrimNodes(
+	nodes []*MerkleNode,
+	ts types.Timestamp,
+
+	pm ProtocolManager,
+	merkle *Merkle,
+
+) []*MerkleNode {
+
+	nNodes := len(nodes)
+	idx := sort.Search(nNodes, func(i int) bool {
+		return ts.IsLessEqual(nodes[i].UpdateTS)
+	})
+
+	return nodes[:idx]
+}
+
+func DiffMerkleTree(
+	myNodes []*MerkleNode,
+	theirNodes []*MerkleNode,
+
+	ts types.Timestamp,
+
+	pm ProtocolManager,
+	merkle *Merkle,
+
+) ([]*MerkleNode, []*MerkleNode, error) {
+
+	myNodes = validateMerkleTreeTrimNodes(myNodes, ts, pm, merkle)
+	theirNodes = validateMerkleTreeTrimNodes(theirNodes, ts, pm, merkle)
+
+	lenMyNodes := len(myNodes)
+	lenTheirNodes := len(theirNodes)
+
+	pMyNodes := myNodes
+	pTheirNodes := theirNodes
+
+	var myNode *MerkleNode
+	var theirNode *MerkleNode
+
+	myNewNodes := make([]*MerkleNode, 0, lenTheirNodes)
+	theirNewNodes := make([]*MerkleNode, 0, lenMyNodes)
+
+	log.Debug("DiffMerkleTree: to for-loop", "myNodes", myNodes, "theirNodes", theirNodes, "ts", ts, "merkle", merkle.Name)
+
+	for len(pMyNodes) > 0 && len(pTheirNodes) > 0 {
+		myNode = pMyNodes[0]
+		theirNode = pTheirNodes[0]
+
+		switch {
+		case myNode.UpdateTS.IsLess(theirNode.UpdateTS):
+			log.Error("DiffMerkleTree: myNode.TS", "me", myNode.UpdateTS, "they", theirNode.UpdateTS, "merkle", merkle.Name)
+			theirNewNodes = append(theirNewNodes, myNode)
+			pMyNodes = pMyNodes[1:]
+		case theirNode.UpdateTS.IsLess(myNode.UpdateTS):
+			log.Error("DiffMerkleTree: theirNode.TS", "me", myNode.UpdateTS, "they", theirNode.UpdateTS, "merkle", merkle.Name)
+			myNewNodes = append(myNewNodes, theirNode)
+			pTheirNodes = pTheirNodes[1:]
+		case myNode.Level > theirNode.Level:
+			log.Error("DiffMerkleTree: myNode.Level", "ts", myNode.UpdateTS, "me", myNode.Level, "they", theirNode.Level, "merkle", merkle.Name)
+			theirNewNodes = append(theirNewNodes, myNode)
+			pMyNodes = pMyNodes[1:]
+		case myNode.Level < theirNode.Level:
+			log.Error("DiffMerkleTree: theirNode.Level", "ts", myNode.UpdateTS, "me", myNode.Level, "they", theirNode.Level, "merkle", merkle.Name)
+			myNewNodes = append(myNewNodes, theirNode)
+			pTheirNodes = pTheirNodes[1:]
+		case myNode.NChildren > theirNode.NChildren:
+			log.Error("DiffMerkleTree: myNode.NChildren", "ts", myNode.UpdateTS, "level", myNode.Level, "me", myNode.NChildren, "they", theirNode.NChildren, "merkle", merkle.Name)
+			theirNewNodes = append(theirNewNodes, myNode)
+			pMyNodes = pMyNodes[1:]
+			pTheirNodes = pTheirNodes[1:]
+		case myNode.NChildren < theirNode.NChildren:
+			log.Error("DiffMerkleTree: theirNode.NChildren", "ts", myNode.UpdateTS, "level", myNode.Level, "me", myNode.NChildren, "they", theirNode.NChildren, "merkle", merkle.Name)
+			myNewNodes = append(myNewNodes, theirNode)
+			pMyNodes = pMyNodes[1:]
+			pTheirNodes = pTheirNodes[1:]
+		default:
+			if !reflect.DeepEqual(myNode.Addr, theirNode.Addr) {
+				log.Error("DiffMerkleTree: Addr", "ts", myNode.UpdateTS, "level", myNode.Level, "me", myNode, "they", theirNode, "merkle", merkle.Name)
+				myNewNodes = append(myNewNodes, theirNode)
+				theirNewNodes = append(theirNewNodes, myNode)
+			}
+
+			pMyNodes = pMyNodes[1:]
+			pTheirNodes = pTheirNodes[1:]
+		}
+	}
+
+	if len(pMyNodes) > 0 {
+		log.Error("DiffMerkleTree: myNodes", "ts", pMyNodes[0].UpdateTS, "level", pMyNodes[0].Level, "merkle", merkle.Name)
+		theirNewNodes = append(theirNewNodes, pMyNodes...)
+	}
+
+	if len(pTheirNodes) > 0 {
+		log.Error("DiffMerkleTree: theirNodes", "ts", pTheirNodes[0].UpdateTS, "level", pTheirNodes[0].Level, "merkle", merkle.Name)
+		myNewNodes = append(myNewNodes, pTheirNodes...)
+	}
+
+	return myNewNodes, theirNewNodes, nil
+}
+
+/*
+Return: myNewKeys: new keys from from their nodes, theirNewKeys: new keys from my nodes
+*/
+func MergeMerkleKeys(myNodes []*MerkleNode, theirNodes []*MerkleNode) ([][]byte, [][]byte, error) {
+	// XXX TODO: refactor. Currently the 4 conditions are enumerated.
+	lenMyNodes := len(myNodes)
+	lenTheirNodes := len(theirNodes)
+
+	/*
+	   for i, myNode := range myNodes {
+	       log.Debug("MergeMerkleNodeKeys: to for-loop", "idx", fmt.Sprintf("(%d/%d)", i, lenMyNodes), "myNode", myNode)
+	   }
+
+	   for i, theirNode := range theirNodes {
+	       log.Debug("MergeMerkleNodeKeys: to for-loop", "idx", fmt.Sprintf("(%d/%d)", i, lenTheirNodes), "theirNode", theirNode)
+	   }
+	*/
+
+	myNewKeys := make([][]byte, 0, lenTheirNodes)
+	theirNewKeys := make([][]byte, 0, lenMyNodes)
+
+	if lenMyNodes == 0 && lenTheirNodes == 0 {
+		return myNewKeys, theirNewKeys, nil
+	}
+
+	var myKey []byte = nil
+	var theirKey []byte = nil
+	if lenTheirNodes == 0 {
+		for pMyNodes, myIdx := myNodes, 0; myIdx < lenMyNodes; pMyNodes, myIdx = pMyNodes[1:], myIdx+1 {
+			myKey = pMyNodes[0].Key
+			theirNewKeys = append(theirNewKeys, myKey)
+		}
+		return myNewKeys, theirNewKeys, nil
+	}
+
+	if lenMyNodes == 0 {
+		for pTheirNodes, theirIdx := theirNodes, 0; theirIdx < lenTheirNodes; pTheirNodes, theirIdx = pTheirNodes[1:], theirIdx+1 {
+			theirKey = pTheirNodes[0].Key
+			myNewKeys = append(myNewKeys, theirKey)
+		}
+		return myNewKeys, theirNewKeys, nil
+	}
+
+	pMyNodes := myNodes
+	myIdx := 0
+	myKey = pMyNodes[0].Key
+
+	pTheirNodes := theirNodes
+	theirIdx := 0
+	theirKey = pTheirNodes[0].Key
+
+	for myIdx < lenMyNodes && theirIdx < lenTheirNodes {
+		cmp := bytes.Compare(myKey, theirKey)
+		//log.Debug("MergeMerkleNodeKeys: after cmp", "idx", fmt.Sprintf("(%d/%d/%d/%d)", myIdx, lenMyNodes, theirIdx, lenTheirNodes), "myKey", myKey, "theirKey", theirKey, "cmp", cmp)
+		if cmp < 0 { // myKey < theirKey
+			theirNewKeys = append(theirNewKeys, myKey)
+			myIdx++
+			if myIdx == lenMyNodes {
+				break
+			}
+			pMyNodes = pMyNodes[1:]
+			myKey = pMyNodes[0].Key
+		} else if cmp > 0 { // myKey > theirKey
+			myNewKeys = append(myNewKeys, theirKey)
+			theirIdx++
+			if theirIdx == lenTheirNodes {
+				break
+			}
+			pTheirNodes = pTheirNodes[1:]
+			theirKey = pTheirNodes[0].Key
+		} else { // myKey == theirKey
+			myIdx++
+			if myIdx < lenMyNodes {
+				pMyNodes = pMyNodes[1:]
+				myKey = pMyNodes[0].Key
+			}
+
+			theirIdx++
+			if theirIdx < lenTheirNodes {
+				pTheirNodes = pTheirNodes[1:]
+				theirKey = pTheirNodes[0].Key
+			}
+		}
+	}
+
+	//log.Debug("MergeMerkleNodeKeys: after for-loop", "myIdx", myIdx, "lenMyNodes", lenMyNodes, "theirNewKeys", theirNewKeys, "theirIdx", theirIdx, "lenTheirNodes", lenTheirNodes, "myNewKeys", myNewKeys)
+
+	for myIdx < lenMyNodes {
+		theirNewKeys = append(theirNewKeys, myKey)
+		myIdx++
+		if myIdx == lenMyNodes {
+			break
+		}
+		pMyNodes = pMyNodes[1:]
+		myKey = pMyNodes[0].Key
+	}
+
+	for theirIdx < lenTheirNodes {
+		myNewKeys = append(myNewKeys, theirKey)
+		theirIdx++
+		if theirIdx == lenTheirNodes {
+			break
+		}
+		pTheirNodes = pTheirNodes[1:]
+		theirKey = pTheirNodes[0].Key
+	}
+
+	//log.Debug("MergeMerkleNodeKeys: after for-loop", "myIdx", myIdx, "lenMyNodes", lenMyNodes, "theirNewKeys", theirNewKeys, "theirIdx", theirIdx, "lenTheirNodes", lenTheirNodes, "myNewKeys", myNewKeys)
+
+	return myNewKeys, theirNewKeys, nil
+}
+
+func DiffMerkleKeys(
+	myKeys [][]byte,
+	theirKeys [][]byte,
+) ([][]byte, [][]byte, error) {
+
+	lenMyKeys := len(myKeys)
+	lenTheirKeys := len(theirKeys)
+
+	pMyKeys := myKeys
+	pTheirKeys := theirKeys
+
+	var myKey []byte
+	var theirKey []byte
+
+	myNewKeys := make([][]byte, 0, lenTheirKeys)
+	theirNewKeys := make([][]byte, 0, lenMyKeys)
+
+	cmp := 0
+	for len(pMyKeys) > 0 && len(pTheirKeys) > 0 {
+		myKey = pMyKeys[0]
+		theirKey = pTheirKeys[0]
+
+		cmp = bytes.Compare(myKey, theirKey)
+		switch {
+		case cmp < 0:
+			theirNewKeys = append(theirNewKeys, myKey)
+			pMyKeys = pMyKeys[1:]
+		case cmp > 0:
+			myNewKeys = append(myNewKeys, theirKey)
+			pTheirKeys = pTheirKeys[1:]
+		default:
+			pMyKeys = pMyKeys[1:]
+			pTheirKeys = pTheirKeys[1:]
+		}
+	}
+
+	if len(pMyKeys) > 0 {
+		theirNewKeys = append(theirNewKeys, pMyKeys...)
+	}
+
+	if len(pTheirKeys) > 0 {
+		myNewKeys = append(myNewKeys, pTheirKeys...)
+	}
+
+	return myNewKeys, theirNewKeys, nil
+}

--- a/service/protocol_create_join_entity.go
+++ b/service/protocol_create_join_entity.go
@@ -146,6 +146,7 @@ func (spm *BaseServiceProtocolManager) CreateJoinEntity(
 	// 8. oplog0
 	log.Debug("CreateJoinEntity: to SetLog0DB", "oplog0", oplog0)
 	pm.SetLog0DB(oplog0)
+	oplog0.IsSync = true
 	err = oplog0.Save(false, pm.Log0Merkle())
 	if err != nil {
 		return nil, err

--- a/service/protocol_force_sync_oplog_ack.go
+++ b/service/protocol_force_sync_oplog_ack.go
@@ -121,7 +121,7 @@ func (pm *BaseProtocolManager) HandleForceSyncOplogAck(
 
 	myNodes = pm.handleSyncOplogAckFilterTS(myNodes, data.StartTS, data.EndTS)
 
-	myNewKeys, theirNewKeys, err := MergeMerkleNodeKeys(myNodes, data.Nodes)
+	myNewKeys, theirNewKeys, err := MergeMerkleKeys(myNodes, data.Nodes)
 	if err != nil {
 		return err
 	}

--- a/service/protocol_force_sync_oplog_by_merkle.go
+++ b/service/protocol_force_sync_oplog_by_merkle.go
@@ -1,0 +1,141 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+type ForceSyncOplogByMerkle struct {
+	UpdateTS types.Timestamp `json:"UT"`
+	Level    MerkleTreeLevel `json:"L"`
+	Keys     [][]byte        `json:"K"`
+}
+
+func (pm *BaseProtocolManager) ForceSyncOplogByMerkle(
+	myNewNode *MerkleNode,
+
+	forceSyncOplogMsg OpType,
+
+	merkle *Merkle,
+
+	peer *PttPeer,
+) error {
+
+	myNode, _ := merkle.GetNodeByLevelTS(myNewNode.Level, myNewNode.UpdateTS)
+
+	log.Debug("ForceSyncOplogByMerkle: to GetChildKeys", "myNode", myNode, "myNewNode", myNewNode, "merkle", merkle.Name)
+
+	keys, err := merkle.GetChildKeys(myNewNode.Level, myNewNode.UpdateTS)
+	log.Debug("ForceSyncOplogByMerkle: after GetChildKeys", "e", err, "level", myNewNode.Level, "TS", myNewNode.UpdateTS, "keys", keys, "merkle", merkle.Name)
+	if err != nil {
+		return err
+	}
+
+	if myNode != nil && len(keys) != int(myNode.NChildren) {
+		log.Warn("ForceSyncOplogByMerkle: len != NChildren", "len", len(keys), "children", myNode.NChildren, "merkle", merkle.Name)
+		return merkle.TryForceSync(pm)
+	}
+
+	if myNode == nil && len(keys) != 0 {
+		log.Warn("ForceSyncOplogByMerkle: len != 0", "len", len(keys), "merkle", merkle.Name)
+		return merkle.TryForceSync(pm)
+	}
+
+	data := &ForceSyncOplogByMerkle{
+		UpdateTS: myNewNode.UpdateTS,
+		Level:    myNewNode.Level,
+		Keys:     keys,
+	}
+
+	err = pm.SendDataToPeer(forceSyncOplogMsg, data, peer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncOplogByMerkle(
+	dataBytes []byte,
+	peer *PttPeer,
+
+	forceSyncOplogAckMsg OpType,
+	forceSyncOplogByOplogAckMsg OpType,
+
+	setDB func(oplog *BaseOplog),
+
+	setNewestOplog func(log *BaseOplog) error,
+
+	merkle *Merkle,
+) error {
+	ptt := pm.Ptt()
+	myInfo := ptt.GetMyEntity()
+	if myInfo.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	e := pm.Entity()
+	if e.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	data := &ForceSyncOplogByMerkle{}
+	err := json.Unmarshal(dataBytes, data)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("HandleForceSyncOplogByMerkle: to GetChildKeys", "level", data.Level, "TS", data.UpdateTS, "merkle", merkle.Name, "peer", peer)
+
+	keys, err := merkle.GetChildKeys(data.Level, data.UpdateTS)
+	log.Debug("HandleForceSyncOplogByMerkle: after GetChildKeys", "level", data.Level, "TS", data.UpdateTS, "keys", keys, "e", err, "merkle", merkle.Name, "peer", peer)
+	if err != nil {
+		return err
+	}
+
+	myNewKeys, theirNewKeys, err := DiffMerkleKeys(keys, data.Keys)
+	log.Debug("HandleForceSyncOplogByMerkle: after DiffMerkleKeys", "myNewKeys", myNewKeys, "theirNewKeys", theirNewKeys, "e", err, "merkle", merkle.Name, "peer", peer)
+	if err != nil {
+		return err
+	}
+
+	if len(theirNewKeys) == 0 {
+		return nil
+	}
+
+	if data.Level == MerkleTreeLevelHR {
+		return pm.ForceSyncOplogByOplogAck(
+			theirNewKeys,
+			forceSyncOplogByOplogAckMsg,
+			setDB,
+			setNewestOplog,
+			peer,
+			merkle,
+		)
+	}
+
+	return pm.ForceSyncOplogByMerkleAck(
+		theirNewKeys,
+		forceSyncOplogAckMsg,
+		merkle,
+		peer,
+	)
+}

--- a/service/protocol_force_sync_oplog_by_merkle_ack.go
+++ b/service/protocol_force_sync_oplog_by_merkle_ack.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+type ForceSyncOplogByMerkleAck struct {
+	Keys [][]byte `json:"K"`
+}
+
+func (pm *BaseProtocolManager) ForceSyncOplogByMerkleAck(
+	keys [][]byte,
+
+	forceSyncOplogAckMsg OpType,
+	merkle *Merkle,
+
+	peer *PttPeer,
+
+) error {
+
+	data := &ForceSyncOplogByMerkleAck{
+		Keys: keys,
+	}
+
+	err := pm.SendDataToPeer(forceSyncOplogAckMsg, data, peer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncOplogByMerkleAck(
+	dataBytes []byte,
+	peer *PttPeer,
+
+	forceSyncOplogMsg OpType,
+
+	merkle *Merkle,
+) error {
+
+	ptt := pm.Ptt()
+	myInfo := ptt.GetMyEntity()
+	if myInfo.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	e := pm.Entity()
+	if e.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	data := &ForceSyncOplogByMerkleAck{}
+	err := json.Unmarshal(dataBytes, data)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("HandleForceSyncOplogByMerkleAck: to for-loop", "keys", data.Keys, "merkle", merkle.Name)
+
+	node := &MerkleNode{}
+	for _, key := range data.Keys {
+		node.ConstructUpdateTSAndLevelByKey(key)
+		log.Debug("HandleForceSyncOplogByMerkleAck: (in-for-loop)", "level", node.Level, "updateTS", node.UpdateTS, "merkle", merkle.Name)
+		pm.ForceSyncOplogByMerkle(node, forceSyncOplogMsg, merkle, peer)
+	}
+
+	return nil
+}

--- a/service/protocol_force_sync_oplog_by_oplog_ack.go
+++ b/service/protocol_force_sync_oplog_by_oplog_ack.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/ailabstw/go-pttai/common/types"
+	"github.com/ailabstw/go-pttai/log"
+)
+
+type ForceSyncOplogByOplogAck struct {
+	Oplogs []*BaseOplog `json:"O"`
+}
+
+func (pm *BaseProtocolManager) ForceSyncOplogByOplogAck(
+	theirNewKeys [][]byte,
+
+	forceSyncOplogByOplogAckMsg OpType,
+
+	setDB func(oplog *BaseOplog),
+	setNewestOplog func(log *BaseOplog) error,
+
+	peer *PttPeer,
+
+	merkle *Merkle,
+) error {
+
+	theirNewLogs, err := getOplogsFromKeys(setDB, theirNewKeys)
+	log.Debug("ForceSyncOplogByOplogAck: after get theirNewLogs", "theirNewLogs", len(theirNewLogs), "e", err, "merkle", merkle.Name)
+	if err != nil {
+		return err
+	}
+
+	if len(theirNewLogs) == 0 {
+		return nil
+	}
+
+	if setNewestOplog != nil {
+		for _, log := range theirNewLogs {
+			setNewestOplog(log)
+		}
+	}
+
+	data := &SyncOplogNewOplogs{
+		Oplogs: theirNewLogs,
+	}
+
+	err = pm.SendDataToPeer(forceSyncOplogByOplogAckMsg, data, peer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncOplogByOplogAck(
+	dataBytes []byte,
+	peer *PttPeer,
+
+	handleOplogs func(oplogs []*BaseOplog, peer *PttPeer, isUpdateSyncTime bool) error,
+
+	merkle *Merkle,
+
+) error {
+
+	ptt := pm.Ptt()
+	myInfo := ptt.GetMyEntity()
+	if myInfo.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	entity := pm.Entity()
+	if entity.GetStatus() != types.StatusAlive {
+		return nil
+	}
+
+	data := &ForceSyncOplogByOplogAck{}
+	err := json.Unmarshal(dataBytes, data)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("HandleForceSyncOplogByOplogAck: to handleOplogs", "oplogs", data.Oplogs, "merkle", merkle.Name)
+
+	err = handleOplogs(data.Oplogs, peer, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/service/protocol_handle_member_oplogs.go
+++ b/service/protocol_handle_member_oplogs.go
@@ -47,10 +47,47 @@ func (pm *BaseProtocolManager) HandleSyncMemberOplog(dataBytes []byte, peer *Ptt
 
 		pm.MemberMerkle(),
 
-		ForceSyncMemberOplogMsg,
-		ForceSyncMemberOplogAckMsg,
+		ForceSyncMemberOplogByMerkleMsg,
+		ForceSyncMemberOplogByMerkleAckMsg,
 		InvalidSyncMemberOplogMsg,
 		SyncMemberOplogAckMsg,
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMemberOplogByMerkle(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkle(
+		dataBytes,
+		peer,
+
+		ForceSyncMemberOplogByMerkleAckMsg,
+		ForceSyncMemberOplogByOplogAckMsg,
+
+		pm.SetMemberDB,
+		pm.SetNewestMemberOplog,
+
+		pm.MemberMerkle(),
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMemberOplogByMerkleAck(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByMerkleAck(
+		dataBytes,
+		peer,
+
+		ForceSyncMemberOplogByMerkleMsg,
+
+		pm.MemberMerkle(),
+	)
+}
+
+func (pm *BaseProtocolManager) HandleForceSyncMemberOplogByOplogAck(dataBytes []byte, peer *PttPeer) error {
+	return pm.HandleForceSyncOplogByOplogAck(
+		dataBytes,
+		peer,
+
+		pm.HandleMemberOplogs,
+
+		pm.MemberMerkle(),
 	)
 }
 
@@ -84,9 +121,9 @@ func (pm *BaseProtocolManager) HandleForceSyncMemberOplogAck(dataBytes []byte, p
 	)
 }
 
-func (pm *BaseProtocolManager) HandleSyncMemberOplogInvalidAck(dataBytes []byte, peer *PttPeer) error {
+func (pm *BaseProtocolManager) HandleSyncMemberOplogInvalid(dataBytes []byte, peer *PttPeer) error {
 
-	return pm.HandleSyncOplogInvalidAck(
+	return pm.HandleSyncOplogInvalid(
 		dataBytes,
 		peer,
 

--- a/service/protocol_manager_utils_handle_message.go
+++ b/service/protocol_manager_utils_handle_message.go
@@ -89,6 +89,28 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 		if err != nil {
 			log.Error("PMHandleMessageWrapper: unable to HandleSyncMasterOplog", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
 		}
+
+	case ForceSyncMasterOplogByMerkleMsg:
+		err = pm.HandleForceSyncMasterOplogByMerkle(dataBytes, peer)
+		if err != nil {
+			log.Error("PMHandleMessageWrapper: unable to HandleForceSyncMasterOplogByMerkle", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
+		}
+	case ForceSyncMasterOplogByMerkleAckMsg:
+		err = pm.HandleForceSyncMasterOplogByMerkleAck(dataBytes, peer)
+		if err != nil {
+			log.Error("PMHandleMessageWrapper: unable to HandleForceSyncMasterOplogByMerkleAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
+		}
+	case ForceSyncMasterOplogByOplogAckMsg:
+		err = pm.HandleForceSyncMasterOplogByOplogAck(dataBytes, peer)
+		if err != nil {
+			log.Error("PMHandleMessageWrapper: unable to HandleForceSyncMasterOplogByOplogAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
+		}
+	case InvalidSyncMasterOplogMsg:
+		err = pm.HandleSyncMasterOplogInvalid(dataBytes, peer)
+		if err != nil {
+			log.Error("PMHandleMessageWrapper: unable to HandleSyncMasterOplogInvalidAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
+		}
+
 	case ForceSyncMasterOplogMsg:
 		err = pm.HandleForceSyncMasterOplog(dataBytes, peer)
 		if err != nil {
@@ -99,11 +121,7 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 		if err != nil {
 			log.Error("PMHandleMessageWrapper: unable to HandleForceSyncMasterOplogAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
 		}
-	case InvalidSyncMasterOplogMsg:
-		err = pm.HandleSyncMasterOplogInvalidAck(dataBytes, peer)
-		if err != nil {
-			log.Error("PMHandleMessageWrapper: unable to HandleSyncMasterOplogInvalidAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
-		}
+
 	case SyncMasterOplogAckMsg:
 		err = pm.HandleSyncMasterOplogAck(dataBytes, peer)
 		if err != nil {
@@ -119,6 +137,7 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 		if err != nil {
 			log.Error("PMHandleMessageWrapper: unable to HandleSyncNewMasterOplogAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
 		}
+
 	case SyncPendingMasterOplogMsg:
 		err = pm.HandleSyncPendingMasterOplog(dataBytes, peer)
 		if err != nil {
@@ -129,6 +148,7 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 		if err != nil {
 			log.Error("PMHandleMessageWrapper: unable to HandleSyncPendingMasterOplogAck", "e", err, "entity", pm.Entity().IDString(), "peer", peer)
 		}
+
 	case AddMasterOplogMsg:
 		err = pm.HandleAddMasterOplog(dataBytes, peer)
 		if err != nil {
@@ -154,12 +174,19 @@ func PMHandleMessageWrapper(pm ProtocolManager, hash *common.Address, encData []
 	case SyncMemberOplogMsg:
 		err = pm.HandleSyncMemberOplog(dataBytes, peer)
 
+	case ForceSyncMemberOplogByMerkleMsg:
+		err = pm.HandleForceSyncMemberOplogByMerkle(dataBytes, peer)
+	case ForceSyncMemberOplogByMerkleAckMsg:
+		err = pm.HandleForceSyncMemberOplogByMerkleAck(dataBytes, peer)
+	case ForceSyncMemberOplogByOplogAckMsg:
+		err = pm.HandleForceSyncMemberOplogByOplogAck(dataBytes, peer)
+	case InvalidSyncMemberOplogMsg:
+		err = pm.HandleSyncMemberOplogInvalid(dataBytes, peer)
+
 	case ForceSyncMemberOplogMsg:
 		err = pm.HandleForceSyncMemberOplog(dataBytes, peer)
 	case ForceSyncMemberOplogAckMsg:
 		err = pm.HandleForceSyncMemberOplogAck(dataBytes, peer)
-	case InvalidSyncMemberOplogMsg:
-		err = pm.HandleSyncMemberOplogInvalidAck(dataBytes, peer)
 
 	case SyncMemberOplogAckMsg:
 		err = pm.HandleSyncMemberOplogAck(dataBytes, peer)

--- a/service/protocol_sync_master_oplog.go
+++ b/service/protocol_sync_master_oplog.go
@@ -23,3 +23,12 @@ type SyncMasterOplog struct {
 func (pm *BaseProtocolManager) SyncPendingMasterOplog(peer *PttPeer) error {
 	return pm.SyncPendingOplog(peer, pm.SetMasterDB, pm.HandleFailedMasterOplog, SyncPendingMasterOplogMsg)
 }
+
+func (pm *BaseProtocolManager) ForceSyncMasterMerkle() (bool, error) {
+	err := pm.masterMerkle.TryForceSync(pm)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/service/protocol_sync_member_oplog.go
+++ b/service/protocol_sync_member_oplog.go
@@ -23,3 +23,12 @@ type SyncMemberOplog struct {
 func (pm *BaseProtocolManager) SyncPendingMemberOplog(peer *PttPeer) error {
 	return pm.SyncPendingOplog(peer, pm.SetMemberDB, pm.HandleFailedMemberOplog, SyncPendingMemberOplogMsg)
 }
+
+func (pm *BaseProtocolManager) ForceSyncMemberMerkle() (bool, error) {
+	err := pm.memberMerkle.TryForceSync(pm)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/service/protocol_sync_oplog_ack.go
+++ b/service/protocol_sync_oplog_ack.go
@@ -254,7 +254,7 @@ func (pm *BaseProtocolManager) HandleSyncOplogAck(
 
 	myNodes = pm.handleSyncOplogAckFilterTS(myNodes, data.StartTS, data.EndTS)
 
-	myNewKeys, theirNewKeys, err := MergeMerkleNodeKeys(myNodes, data.Nodes)
+	myNewKeys, theirNewKeys, err := MergeMerkleKeys(myNodes, data.Nodes)
 	log.Debug("HandleSyncOplogAck: after MergeMerkleNodeKeys", "myNewKeys", myNewKeys, "theirNewKeys", theirNewKeys, "myNodes", myNodes, "startTS", data.StartTS, "endTS", data.EndTS, "e", err, "entity", pm.Entity().GetID())
 	if err != nil {
 		return err

--- a/service/protocol_sync_oplog_invalid.go
+++ b/service/protocol_sync_oplog_invalid.go
@@ -34,7 +34,7 @@ SyncOplogAckInvalid: I (The receiver) Issuing that the sync-oplog is invalid (Va
 	2. if isToSyncPeer: ResyncOplog (with resyncOp. I become the requester.)
 	3. Send invalidOp to the peer (notify it that the oplog is invalid. the peer needs to do some action and resync the oplog.)
 */
-func (pm *BaseProtocolManager) SyncOplogInvalidAck(
+func (pm *BaseProtocolManager) SyncOplogInvalid(
 	peer *PttPeer,
 
 	theirSyncTS types.Timestamp,
@@ -86,7 +86,7 @@ syncOplogAckInvalidIsToSyncPeer checks whether I should sync with the peer.
 	4. => cmp sync-ts.
 	5. => cmp id.
 */
-func (pm *BaseProtocolManager) syncOplogInvalidAckIsToSyncPeer(
+func (pm *BaseProtocolManager) syncOplogInvalidIsToSyncPeer(
 	peer *PttPeer,
 	theirSyncTS types.Timestamp,
 	mySyncTS types.Timestamp,
@@ -142,7 +142,7 @@ HandleSyncOplogAckInvalid: I (the requester) received the msg that my oplogs are
     3.1. if I am connecting to the master => get the master-peer and resync with the master.
     4. Try to connect to the master.
 */
-func (pm *BaseProtocolManager) HandleSyncOplogInvalidAck(
+func (pm *BaseProtocolManager) HandleSyncOplogInvalid(
 	dataBytes []byte,
 	peer *PttPeer,
 	merkle *Merkle,

--- a/service/protocol_sync_oplog_invalid_by_merkle.go
+++ b/service/protocol_sync_oplog_invalid_by_merkle.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The go-pttai Authors
+// This file is part of the go-pttai library.
+//
+// The go-pttai library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-pttai library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-pttai library. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import "github.com/ailabstw/go-pttai/log"
+
+func (pm *BaseProtocolManager) SyncOplogInvalidByMerkle(
+	myNewNodes []*MerkleNode,
+	theirNewNodes []*MerkleNode,
+
+	forceSyncOplogMsg OpType,
+	forceSyncOplogAckMsg OpType,
+
+	merkle *Merkle,
+
+	peer *PttPeer,
+
+) error {
+
+	var err error
+	log.Debug("SyncOplogInvalidByMerkle: to ForceSyncOplogByMerkle", "myNewNodes", myNewNodes, "merkle", merkle.Name, "peer", peer)
+	for _, node := range myNewNodes {
+		err = pm.ForceSyncOplogByMerkle(
+			node,
+
+			forceSyncOplogMsg,
+
+			merkle,
+			peer,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(theirNewNodes) == 0 {
+		return nil
+	}
+
+	theirNewKeys := make([][]byte, 0, len(theirNewNodes))
+	var theirNewKey []byte
+	for _, node := range theirNewNodes {
+		theirNewKey = node.ToKey(merkle)
+		theirNewKeys = append(theirNewKeys, theirNewKey)
+	}
+
+	log.Debug("SyncOplogInvalidByMerkle: to ForceSyncOplogByMerkleAck", "theirNewkeys", theirNewKeys, "merkle", merkle.Name, "peer", peer)
+
+	err = pm.ForceSyncOplogByMerkleAck(
+		theirNewKeys,
+
+		forceSyncOplogAckMsg,
+
+		merkle,
+		peer,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/service/protocol_update_object_logs.go
+++ b/service/protocol_update_object_logs.go
@@ -172,6 +172,8 @@ func (pm *BaseProtocolManager) handleUpdateObjectCore(
 
 	// prelog
 	if !reflect.DeepEqual(origObj.GetLogID(), oplog.PreLogID) {
+		log.Warn("handleUpdateObjectCore: not fit PreLogID", "obj.LogID", origObj.GetLogID(), "PreLogID", oplog.PreLogID, "entity", pm.Entity().IDString())
+
 		return ErrInvalidPreLog
 	}
 
@@ -327,7 +329,7 @@ func (pm *BaseProtocolManager) handleUpdateObjectWithNewSyncInfo(
 
 	syncLogID := syncInfo.GetLogID()
 	if reflect.DeepEqual(syncLogID, oplog.ID) {
-		err = pm.handleUpdateObjectSameLog(obj, newSyncInfo, oplog, postupdate)
+		err = pm.handleUpdateObjectSameLog(obj, syncInfo, oplog, postupdate)
 		return nil, err
 	}
 
@@ -355,7 +357,8 @@ func (pm *BaseProtocolManager) handleUpdateObjectWithNewSyncInfo(
 
 func (pm *BaseProtocolManager) handleUpdateObjectSameLog(
 	obj Object,
-	newSyncInfo SyncInfo,
+
+	origSyncInfo SyncInfo,
 
 	oplog *BaseOplog,
 
@@ -364,7 +367,9 @@ func (pm *BaseProtocolManager) handleUpdateObjectSameLog(
 
 	obj.SetSyncInfo(nil)
 
-	return pm.handleUpdateObjectNewLog(obj, newSyncInfo, oplog, postupdate)
+	log.Debug("handleUpdateObjectSameLog: to handleUpdateObjectNewLog", "entity", pm.Entity().IDString(), "oplog", oplog.ID)
+
+	return pm.handleUpdateObjectNewLog(obj, origSyncInfo, oplog, postupdate)
 
 }
 
@@ -422,6 +427,8 @@ func (pm *BaseProtocolManager) handleUpdateObjectNewLog(
 	isAllGood := newSyncInfo.CheckIsAllGood()
 
 	status := oplog.ToStatus()
+
+	log.Debug("handleUpdateObjectNewLog: to check", "isAllGood", isAllGood, "status", status, "entity", pm.Entity().IDString(), "oplog", oplog.ID)
 
 	if isAllGood && status == types.StatusAlive {
 		err = newSyncInfo.ToObject(obj)

--- a/service/service_core.go
+++ b/service/service_core.go
@@ -92,6 +92,14 @@ func (svc *BaseService) GetMasterOplogMerkleNodeList(entityIDBytes []byte, level
 	return results, nil
 }
 
+func (svc *BaseService) ForceSyncMasterMerkle(entityIDBytes []byte) (bool, error) {
+	pm, err := svc.EntityIDToPM(entityIDBytes)
+	if err != nil {
+		return false, err
+	}
+	return pm.ForceSyncMasterMerkle()
+}
+
 /**********
  * Master List
  **********/
@@ -188,6 +196,14 @@ func (svc *BaseService) GetMemberOplogMerkleNodeList(entityIDBytes []byte, level
 	}
 
 	return results, nil
+}
+
+func (svc *BaseService) ForceSyncMemberMerkle(entityIDBytes []byte) (bool, error) {
+	pm, err := svc.EntityIDToPM(entityIDBytes)
+	if err != nil {
+		return false, err
+	}
+	return pm.ForceSyncMemberMerkle()
 }
 
 /**********


### PR DESCRIPTION
intends to deal with #190 

1. rename sync-oplog-invalid
2. merkle_utils.
3. sync-oplog-invalid-by-merkle. force-sync-oplog-by-merkle. force-syncoplog-by-merkle-ack. force-sync-oplog-by-oplog-ack
4. master-oplog, member-oplog, me-oplog, user-oplog, content-oplog. friend-oplog.
5. api.force-sync-merkle
6. merkle.Name includes entity info.
7. ensuring that only valid-sync oplog is in merkle-tree.
8. fix update-object-logs.
9. delete merkle-key if nChildren == 0.
10. remove oplog.SaveWithSync.
11. oplog.SelectExisting add origIsSync.
12. oplog.IntegrateExisting add origIsSync.
13. pm.IntegrateOplog add origIsSync
14. oplog0.IsSync in CreateJoinEntity.
15. origSyncInfo in handleUpdateObjectSameLog.