### PR TITLE
fix syntax error in crypto/bn256/google/main_test.go

### DIFF
--- a/crypto/bn256/google/main_test.go
+++ b/crypto/bn256/google/main_test.go
@@ -13,7 +13,7 @@ func TestRandomG2Marshal(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		t.Logf("%d: %x\n", n, g2.Marshal())
+		t.Logf("%v: %x\n", n, g2.Marshal())
 	}
 }
 


### PR DESCRIPTION
Currently, `make test` will fail due to a syntax error in `crypto/bn256/google/main_test.go`:

```
...
crypto/bn256/google/main_test.go:16:3: Logf format %d has arg n of wrong type *math/big.Int
FAIL    github.com/ailabstw/go-pttai/crypto/bn256/google [build failed]
...
util.go:61: exit status 2
exit status 1
make: *** [test] Error 1
```

This PR simply fix the log format since it's not critical for the actual test.