### PR TITLE
E2E test cleanup

### DIFF
--- a/.cc/scripts/e2e.sh
+++ b/.cc/scripts/e2e.sh
@@ -10,7 +10,6 @@ regex=`echo "$@" | perl -pe 's/(^|_)(\w)/\U\2/g'`
 echo "regex: ${regex}"
 
 make
-make p2pbootnode
 
 gotest -v -timeout 300s -run "${regex}" "./e2e"
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Testing for specific e2e-test
 
     ./scripts/e2e.sh [any test in the e2e dir]
 
-ex: ./scripts/e2e.sh friend_basic runs TestFriendBasic
+ex: ./scripts/e2e.sh friend_basic
 
 
 Running Godoc


### PR DESCRIPTION
1. remove `make p2pbootnode` from `scripts/e2e.sh`
2. fix e2e test instruction in README